### PR TITLE
feat: export C-ABI functions

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -17,7 +17,7 @@ pub fn build(b: *std.Build) !void {
 
     // build blst-z static library
     const staticLib = b.addStaticLibrary(.{
-        .name = "blst-z",
+        .name = "blst",
         // In this case the main source file is merely a path, however, in more
         // complicated build scripts, this could be a generated file.
         .root_source_file = b.path("src/root.zig"),
@@ -56,8 +56,8 @@ pub fn build(b: *std.Build) !void {
 
     // build blst-z shared library
     const sharedLib = b.addSharedLibrary(.{
-        .name = "blst-z",
-        .root_source_file = b.path("src/c_abi.zig"),
+        .name = "blst_min_pk",
+        .root_source_file = b.path("src/sig_variant_min_pk.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig
+++ b/build.zig
@@ -15,7 +15,8 @@ pub fn build(b: *std.Build) !void {
     // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addStaticLibrary(.{
+    // build blst-z static library
+    const staticLib = b.addStaticLibrary(.{
         .name = "blst-z",
         // In this case the main source file is merely a path, however, in more
         // complicated build scripts, this could be a generated file.
@@ -39,19 +40,30 @@ pub fn build(b: *std.Build) !void {
     if (!file_exist) {
         const blst_step = b.addSystemCommand(([_][]const u8{"./build.sh"})[0..]);
         blst_step.cwd = b.path("blst");
-        lib.step.dependOn(&blst_step.step);
+        staticLib.step.dependOn(&blst_step.step);
     }
 
     // Add the static library, this point to the output file
-    lib.addObjectFile(b.path(blst_file_path));
+    staticLib.addObjectFile(b.path(blst_file_path));
 
     // the folder where blst.h is located
-    lib.addIncludePath(b.path("blst/bindings"));
+    staticLib.addIncludePath(b.path("blst/bindings"));
 
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when
     // running `zig build`).
-    b.installArtifact(lib);
+    b.installArtifact(staticLib);
+
+    // build blst-z shared library
+    const sharedLib = b.addSharedLibrary(.{
+        .name = "blst-z",
+        .root_source_file = b.path("src/c_abi.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    sharedLib.addObjectFile(b.path(blst_file_path));
+    sharedLib.addIncludePath(b.path("blst/bindings"));
+    b.installArtifact(sharedLib);
 
     const exe = b.addExecutable(.{
         .name = "blst-z",
@@ -96,7 +108,7 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     });
 
-    lib_unit_tests.linkLibrary(lib);
+    lib_unit_tests.linkLibrary(staticLib);
     // it's optional to do this on MacOS, but required in CI
     lib_unit_tests.addObjectFile(b.path(blst_file_path));
     lib_unit_tests.addIncludePath(b.path("blst/bindings"));

--- a/src/pairing.zig
+++ b/src/pairing.zig
@@ -21,26 +21,26 @@ const PairingPk = union(PTag) {
 };
 
 pub const Pairing = struct {
-    v: []u8,
+    v: [*c]u8,
 
     /// Rust always use a heap allocation here, but adding an allocator as param for Zig is too complex
     /// instead of that we provide a buffer that's big enough for the struct to operate on so that:
     /// - it does not have allocator in its api
     /// - can use stack allocation at consumer side
     /// - can reuse memory if it makes sense at consumer side
-    pub fn new(buffer: []u8, hash_or_encode: bool, dst: []const u8) PairingError!Pairing {
-        if (buffer.len < c.blst_pairing_sizeof()) {
+    pub fn new(buffer: [*c]u8, buffer_len: usize, hash_or_encode: bool, dst: [*c]const u8, dst_len: usize) PairingError!Pairing {
+        if (buffer_len < c.blst_pairing_sizeof()) {
             return PairingError.BufferTooSmall;
         }
 
-        if (dst.len == 0) {
+        if (dst_len == 0) {
             return PairingError.DstTooSmall;
         }
 
         var obj = Pairing{
-            .v = buffer[0..c.blst_pairing_sizeof()],
+            .v = buffer,
         };
-        obj.init(hash_or_encode, dst);
+        obj.init(hash_or_encode, dst, dst_len);
 
         return obj;
     }
@@ -50,12 +50,12 @@ pub const Pairing = struct {
         return c.blst_pairing_sizeof();
     }
 
-    fn init(self: *Pairing, hash_or_encode: bool, dst: []const u8) void {
-        c.blst_pairing_init(self.ctx(), hash_or_encode, &dst[0], dst.len);
+    fn init(self: *Pairing, hash_or_encode: bool, dst: [*c]const u8, dst_len: usize) void {
+        c.blst_pairing_init(self.ctx(), hash_or_encode, dst, dst_len);
     }
 
     fn ctx(self: *Pairing) *c.blst_pairing {
-        const ptr: *c.blst_pairing = @ptrCast(&self.v[0]);
+        const ptr: *c.blst_pairing = @ptrCast(self.v);
         return ptr;
     }
 
@@ -64,24 +64,24 @@ pub const Pairing = struct {
         return ptr;
     }
 
-    pub fn aggregateG1(self: *Pairing, pk: *const c.blst_p1_affine, pk_validate: bool, sig: ?*const c.blst_p2_affine, sig_groupcheck: bool, msg: []const u8, aug: ?[]const u8) BLST_ERROR!void {
+    pub fn aggregateG1(self: *Pairing, pk: *const c.blst_p1_affine, pk_validate: bool, sig: ?*const c.blst_p2_affine, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, aug: ?[]const u8) BLST_ERROR!void {
         const aug_ptr = if (aug != null and aug.?.len > 0) &aug.?[0] else null;
         const aug_len = if (aug != null) aug.?.len else 0;
         const sig_ptr = if (sig != null) sig.? else null;
 
-        const res = c.blst_pairing_chk_n_aggr_pk_in_g1(self.ctx(), pk, pk_validate, sig_ptr, sig_groupcheck, &msg[0], msg.len, aug_ptr, aug_len);
+        const res = c.blst_pairing_chk_n_aggr_pk_in_g1(self.ctx(), pk, pk_validate, sig_ptr, sig_groupcheck, msg, msg_len, aug_ptr, aug_len);
 
         if (toBlstError(res)) |err| {
             return err;
         }
     }
 
-    pub fn aggregateG2(self: *Pairing, pk: *const c.blst_p2_affine, pk_validate: bool, sig: ?*const c.blst_p1_affine, sig_groupcheck: bool, msg: []const u8, aug: ?[]const u8) BLST_ERROR!void {
+    pub fn aggregateG2(self: *Pairing, pk: *const c.blst_p2_affine, pk_validate: bool, sig: ?*const c.blst_p1_affine, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, aug: ?[]const u8) BLST_ERROR!void {
         const aug_ptr = if (aug != null and aug.?.len > 0) &aug.?[0] else null;
         const aug_len = if (aug != null) aug.?.len else 0;
         const sig_ptr = if (sig != null) sig.? else null;
 
-        const res = c.blst_pairing_chk_n_aggr_pk_in_g2(self.ctx(), pk, pk_validate, sig_ptr, sig_groupcheck, &msg[0], msg.len, aug_ptr, aug_len);
+        const res = c.blst_pairing_chk_n_aggr_pk_in_g2(self.ctx(), pk, pk_validate, sig_ptr, sig_groupcheck, msg, msg_len, aug_ptr, aug_len);
 
         if (toBlstError(res)) |err| {
             return err;
@@ -90,22 +90,22 @@ pub const Pairing = struct {
 
     // TODO: msgs and scalar should have len > 0
     // check for other apis as well
-    pub fn mulAndAggregateG1(self: *Pairing, pk: *const c.blst_p1_affine, pk_validate: bool, sig: *const c.blst_p2_affine, sig_groupcheck: bool, scalar: []const u8, nbits: usize, msg: []const u8, aug: ?[]const u8) BLST_ERROR!void {
+    pub fn mulAndAggregateG1(self: *Pairing, pk: *const c.blst_p1_affine, pk_validate: bool, sig: *const c.blst_p2_affine, sig_groupcheck: bool, scalar: [*c]const u8, nbits: usize, msg: [*c]const u8, msg_len: usize, aug: ?[]const u8) BLST_ERROR!void {
         const aug_ptr = if (aug != null and aug.?.len > 0) &aug.?[0] else null;
         const aug_len = if (aug != null) aug.?.len else 0;
 
-        const res = c.blst_pairing_chk_n_mul_n_aggr_pk_in_g1(self.ctx(), pk, pk_validate, sig, sig_groupcheck, &scalar[0], nbits, &msg[0], msg.len, aug_ptr, aug_len);
+        const res = c.blst_pairing_chk_n_mul_n_aggr_pk_in_g1(self.ctx(), pk, pk_validate, sig, sig_groupcheck, scalar, nbits, msg, msg_len, aug_ptr, aug_len);
 
         if (toBlstError(res)) |err| {
             return err;
         }
     }
 
-    pub fn mulAndAggregateG2(self: *Pairing, pk: *const c.blst_p2_affine, pk_validate: bool, sig: *const c.blst_p1_affine, sig_groupcheck: bool, scalar: []const u8, nbits: usize, msg: []const u8, aug: ?[]const u8) BLST_ERROR!void {
+    pub fn mulAndAggregateG2(self: *Pairing, pk: *const c.blst_p2_affine, pk_validate: bool, sig: *const c.blst_p1_affine, sig_groupcheck: bool, scalar: [*c]const u8, nbits: usize, msg: [*c]const u8, msg_len: usize, aug: ?[]const u8) BLST_ERROR!void {
         const aug_ptr = if (aug != null and aug.?.len > 0) &aug.?[0] else null;
         const aug_len = if (aug != null) aug.?.len else 0;
 
-        const res = c.blst_pairing_chk_n_mul_n_aggr_pk_in_g2(self.ctx(), pk, pk_validate, sig, sig_groupcheck, &scalar[0], nbits, &msg[0], msg.len, aug_ptr, aug_len);
+        const res = c.blst_pairing_chk_n_mul_n_aggr_pk_in_g2(self.ctx(), pk, pk_validate, sig, sig_groupcheck, scalar, nbits, msg, msg_len, aug_ptr, aug_len);
 
         if (toBlstError(res)) |err| {
             return err;
@@ -152,7 +152,7 @@ test "init Pairing" {
     defer allocator.free(buffer);
 
     const dst = "destination";
-    _ = try Pairing.new(buffer, true, dst);
+    _ = try Pairing.new(&buffer[0], buffer.len, true, &dst[0], dst.len);
 }
 
 test "sizeOf Pairing" {

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,7 +1,25 @@
 const std = @import("std");
 const testing = std.testing;
-pub const min_pk = @import("./sig_variant_min_pk.zig").min_pk;
-pub const min_sig = @import("./sig_variant_min_sig.zig").min_sig;
+pub const min_pk_sig_variant = @import("./sig_variant_min_pk.zig");
+pub const min_sig_sig_variant = @import("./sig_variant_min_sig.zig");
+
+pub const min_pk = struct {
+    pub const PublicKey = min_pk_sig_variant.PublicKey;
+    pub const AggregatePublicKey = min_pk_sig_variant.AggregatePublicKey;
+    pub const Signature = min_pk_sig_variant.Signature;
+    pub const AggregateSignature = min_pk_sig_variant.AggregateSignature;
+    pub const SecretKey = min_pk_sig_variant.SecretKey;
+    pub const aggregateWithRandomness = min_pk_sig_variant.aggregateWithRandomness;
+};
+
+pub const min_sig = struct {
+    pub const PublicKey = min_sig_sig_variant.PublicKey;
+    pub const AggregatePublicKey = min_sig_sig_variant.AggregatePublicKey;
+    pub const Signature = min_sig_sig_variant.Signature;
+    pub const AggregateSignature = min_sig_sig_variant.AggregateSignature;
+    pub const SecretKey = min_sig_sig_variant.SecretKey;
+    pub const aggregateWithRandomness = min_sig_sig_variant.aggregateWithRandomness;
+};
 
 test {
     testing.refAllDecls(@This());

--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -1314,6 +1314,10 @@ pub fn createSigVariant(
             return agg_pk;
         }
 
+        pub fn addPublicKeysC(out: *pk_type, pks: [*c]*const pk_aff_type, pks_len: usize) void {
+            PkMultiPoint.add(out, pks, pks_len);
+        }
+
         // scratch param is designed to be reused across multiple calls
         pub fn multPublicKeys(pks: []*const PublicKey, scalars: []*const u8, n_bits: usize, scratch: []u64) AggregatePublicKey {
             // this is unsafe code but we scanned through testTypeAlignment unit test
@@ -1322,6 +1326,10 @@ pub fn createSigVariant(
             var agg_pk = AggregatePublicKey.default();
             PkMultiPoint.mult(&agg_pk.point, &pk_aff_points[0], pk_aff_points.len, &scalars[0], n_bits, &scratch[0]);
             return agg_pk;
+        }
+
+        pub fn multPublicKeysC(out: *pk_type, pks: [*c]*const pk_aff_type, pks_len: usize, scalars: [*c]*const u8, n_bits: usize, scratch: [*c]u64) void {
+            PkMultiPoint.mult(out, pks, pks_len, scalars, n_bits, scratch);
         }
 
         pub fn addSignatures(sigs: []*const Signature) AggregateSignature {
@@ -1333,6 +1341,10 @@ pub fn createSigVariant(
             return agg_sig;
         }
 
+        pub fn addSignaturesC(out: *sig_type, sigs: [*c]*const sig_aff_type, sigs_len: usize) void {
+            SigMultiPoint.add(out, sigs, sigs_len);
+        }
+
         // scratch param is designed to be reused across multiple calls
         pub fn multSignatures(sigs: []*const Signature, scalars: []*const u8, n_bits: usize, scratch: []u64) AggregateSignature {
             // this is unsafe code but we scanned through testTypeAlignment unit test
@@ -1341,6 +1353,10 @@ pub fn createSigVariant(
             var agg_sig = AggregateSignature.default();
             SigMultiPoint.mult(&agg_sig.point, &sig_aff_points[0], sig_aff_points.len, &scalars[0], n_bits, &scratch[0]);
             return agg_sig;
+        }
+
+        pub fn multSignaturesC(out: *sig_type, sigs: [*c]*const sig_aff_type, sigs_len: usize, scalars: [*c]*const u8, n_bits: usize, scratch: [*c]u64) void {
+            SigMultiPoint.mult(out, sigs, sigs_len, scalars, n_bits, scratch);
         }
 
         /// testing methods for this lib, should not export to consumers

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -80,6 +80,8 @@ pub const aggregateWithRandomness = SigVariant.aggregateWithRandomness;
 /// exported C-ABI functions need to be declared at top level, and they only work with extern struct
 const PublicKeyType = SigVariant.getPublicKeyType();
 const AggregatePublicKeyType = SigVariant.getAggregatePublicKeyType();
+const SignatureType = SigVariant.getSignatureType();
+const AggregateSignatureType = SigVariant.getAggregateSignatureType();
 
 /// PublicKey functions
 export fn defaultPublicKey(out: *PublicKeyType) void {
@@ -161,6 +163,73 @@ export fn addPublicKeyToAggregate(out: *AggregatePublicKeyType, pk: *const Publi
 
 export fn isAggregatePublicKeyEqual(agg_pk: *const AggregatePublicKeyType, other: *const AggregatePublicKeyType) bool {
     return AggregatePublicKey.isAggregatePublicKeyEqual(agg_pk, other);
+}
+
+/// Signature functions
+export fn defaultSignature(out: *SignatureType) void {
+    return Signature.defaultSignature(out);
+}
+
+export fn validateSignature(sig: *const SignatureType, sig_infcheck: bool) c_uint {
+    return Signature.validateSignature(sig, sig_infcheck);
+}
+
+export fn signatureBytesValidate(sig: [*c]const u8, sig_len: usize, sig_infcheck: bool) c_uint {
+    return Signature.signatureBytesValidate(sig, sig_len, sig_infcheck);
+}
+
+export fn verifySignature(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, dst: [*c]const u8, dst_len: usize, aug_ptr: [*c]const u8, aug_len: usize, pk: *const PublicKeyType, pk_validate: bool) c_uint {
+    return Signature.verifySignature(sig, sig_groupcheck, msg, msg_len, dst, dst_len, aug_ptr, aug_len, pk, pk_validate);
+}
+
+export fn aggregateVerify(sig: *const SignatureType, sig_groupcheck: bool, msgs: [*c][*c]const u8, msgs_len: usize, msg_len: usize, dst: [*c]const u8, dst_len: usize, pks: [*c]const *PublicKeyType, pks_len: usize, pks_validate: bool, pairing_buffer: [*c]u8, pairing_buffer_len: usize) c_uint {
+    return Signature.aggregateVerifyC(sig, sig_groupcheck, msgs, msgs_len, msg_len, dst, dst_len, pks, pks_len, pks_validate, pairing_buffer, pairing_buffer_len);
+}
+
+// TODO: fastAggregateVerify: wait for AggregateSignatureType to be implemented
+
+export fn fastAggregateVerifyPreAggregated(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, dst: [*c]const u8, dst_len: usize, pk: *PublicKeyType, pairing_buffer: [*c]u8, pairing_buffer_len: usize) c_uint {
+    return Signature.fastAggregateVerifyPreAggregatedC(sig, sig_groupcheck, msg, msg_len, dst, dst_len, pk, pairing_buffer, pairing_buffer_len);
+}
+
+export fn verifyMultipleSignatures(msgs: [*c][*c]const u8, msgs_len: usize, msg_len: usize, dst: [*c]const u8, dst_len: usize, pks: [*c]*const PublicKeyType, pks_len: usize, pks_validate: bool, sigs: [*c]*const SignatureType, sigs_len: usize, sigs_groupcheck: bool, rands: [*c][*c]const u8, rands_len: usize, rand_bits: usize, pairing_buffer: [*c]u8, pairing_buffer_len: usize) c_uint {
+    return Signature.verifyMultipleSignatures(msgs, msgs_len, msg_len, dst, dst_len, pks, pks_len, pks_validate, sigs, sigs_len, sigs_groupcheck, rands, rands_len, rand_bits, pairing_buffer, pairing_buffer_len);
+}
+
+export fn signatureFromAggregate(out: *SignatureType, agg_sig: *const AggregateSignatureType) void {
+    Signature.signatureFromAggregate(out, agg_sig);
+}
+
+export fn compressSignature(out: *u8, point: *const SignatureType) void {
+    Signature.compressSignature(out, point);
+}
+
+export fn serializeSignature(out: *u8, point: *const SignatureType) void {
+    Signature.serializeSignature(out, point);
+}
+
+export fn uncompressSignature(out: *SignatureType, sig_comp: [*c]const u8, len: usize) c_uint {
+    return Signature.uncompressSignature(out, sig_comp, len);
+}
+
+export fn deserializeSignature(out: *SignatureType, sig_in: [*c]const u8, len: usize) c_uint {
+    return Signature.deserializeSignature(out, sig_in, len);
+}
+
+export fn signatureFromBytes(out: *SignatureType, sig_in: [*c]const u8, len: usize) c_uint {
+    return Signature.signatureFromBytes(out, sig_in, len);
+}
+
+export fn signatureToBytes(out: *u8, point: *SignatureType) void {
+    return Signature.signatureToBytes(out, point);
+}
+
+export fn signatureSubgroupCheck(point: *SignatureType) bool {
+    return Signature.signatureSubgroupCheck(point);
+}
+
+export fn isSignatureEqual(point: *const SignatureType, other: *const SignatureType) bool {
+    return Signature.isSignatureEqual(point, other);
 }
 
 test "test_sign_n_verify" {

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -175,8 +175,8 @@ export fn validateSignature(sig: *const SignatureType, sig_infcheck: bool) c_uin
     return Signature.validateSignature(sig, sig_infcheck);
 }
 
-export fn signatureBytesValidate(sig: [*c]const u8, sig_len: usize, sig_infcheck: bool) c_uint {
-    return Signature.signatureBytesValidate(sig, sig_len, sig_infcheck);
+export fn sigValidate(out: *SignatureType, sig: [*c]const u8, sig_len: usize, sig_infcheck: bool) c_uint {
+    return Signature.sigValidateC(out, sig, sig_len, sig_infcheck);
 }
 
 export fn verifySignature(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, dst: [*c]const u8, dst_len: usize, aug_ptr: [*c]const u8, aug_len: usize, pk: *const PublicKeyType, pk_validate: bool) c_uint {
@@ -343,6 +343,8 @@ export fn addSignatures(out: *AggregateSignatureType, sigs: [*c]*const Signature
 export fn multSignaturesC(out: *AggregateSignatureType, sigs: [*c]*const SignatureType, sigs_len: usize, scalars: [*c]*const u8, n_bits: usize, scratch: [*c]u64) void {
     return SigVariant.multSignaturesC(out, sigs, sigs_len, scalars, n_bits, scratch);
 }
+
+// TODO: aggregateWithRandomnessC: need to implement extern struct
 
 test "test_sign_n_verify" {
     try SigVariant.testSignNVerify();

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -187,7 +187,9 @@ export fn aggregateVerify(sig: *const SignatureType, sig_groupcheck: bool, msgs:
     return Signature.aggregateVerifyC(sig, sig_groupcheck, msgs, msgs_len, msg_len, dst, dst_len, pks, pks_len, pks_validate, pairing_buffer, pairing_buffer_len);
 }
 
-// TODO: fastAggregateVerify: wait for AggregateSignatureType to be implemented
+export fn fastAggregateVerify(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, dst: [*c]const u8, dst_len: usize, pks: [*c]*const PublicKeyType, pks_len: usize, pairing_buffer: [*c]u8, pairing_buffer_len: usize) c_uint {
+    return Signature.fastAggregateVerifyC(sig, sig_groupcheck, msg, msg_len, dst, dst_len, pks, pks_len, pairing_buffer, pairing_buffer_len);
+}
 
 export fn fastAggregateVerifyPreAggregated(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, dst: [*c]const u8, dst_len: usize, pk: *PublicKeyType, pairing_buffer: [*c]u8, pairing_buffer_len: usize) c_uint {
     return Signature.fastAggregateVerifyPreAggregatedC(sig, sig_groupcheck, msg, msg_len, dst, dst_len, pk, pairing_buffer, pairing_buffer_len);

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -82,6 +82,7 @@ const PublicKeyType = SigVariant.getPublicKeyType();
 const AggregatePublicKeyType = SigVariant.getAggregatePublicKeyType();
 const SignatureType = SigVariant.getSignatureType();
 const AggregateSignatureType = SigVariant.getAggregateSignatureType();
+const SecretKeyType = SigVariant.getSecretKeyType();
 
 /// PublicKey functions
 export fn defaultPublicKey(out: *PublicKeyType) void {
@@ -271,6 +272,59 @@ export fn subgroupCheckC(agg_sig: *const AggregateSignatureType) bool {
 
 export fn isAggregateSignatureEqual(point: *const AggregateSignatureType, other: *const AggregateSignatureType) bool {
     return AggregateSignature.isAggregateSignatureEqual(point, other);
+}
+
+// SecretKeyType functions
+export fn defaultSecretKey(out: *SecretKeyType) void {
+    return SecretKey.defaultSecretKey(out);
+}
+
+export fn secretKeyGen(out: *SecretKeyType, ikm: [*c]const u8, ikm_len: usize, key_info: [*c]const u8, key_info_len: usize) c_uint {
+    return SecretKey.secretKeyGen(out, ikm, ikm_len, key_info, key_info_len);
+}
+
+export fn secretKeyGenV3(out: *SecretKeyType, ikm: [*c]const u8, ikm_len: usize, key_info: [*c]const u8, key_info_len: usize) c_uint {
+    return SecretKey.secretKeyGenV3(out, ikm, ikm_len, key_info, key_info_len);
+}
+
+export fn secretKeyGenV45(out: *SecretKeyType, ikm: [*c]const u8, ikm_len: usize, salt: [*c]const u8, salt_len: usize, info: [*c]const u8, info_len: usize) c_uint {
+    return SecretKey.secretKeyGenV45(out, ikm, ikm_len, salt, salt_len, info, info_len);
+}
+
+export fn secretKeyGenV5(out: *SecretKeyType, ikm: [*c]const u8, ikm_len: usize, salt: [*c]const u8, salt_len: usize, info: [*c]const u8, info_len: usize) c_uint {
+    return SecretKey.secretKeyGenV5(out, ikm, ikm_len, salt, salt_len, info, info_len);
+}
+
+export fn secretKeyDeriveMasterEip2333(out: *SecretKeyType, ikm: [*c]const u8, ikm_len: usize) c_uint {
+    return SecretKey.secretKeyDeriveMasterEip2333(out, ikm, ikm_len);
+}
+
+export fn secretKeyDeriveChildEip2333(out: *SecretKeyType, sk: *const SecretKeyType, child_index: u32) void {
+    SecretKey.secretKeyDeriveChildEip2333(out, sk, child_index);
+}
+
+export fn secretKeyToPublicKey(out: *PublicKeyType, sk: *const SecretKeyType) void {
+    return SecretKey.secretKeyToPublicKey(out, sk);
+}
+
+export fn sign(out: *SignatureType, sk: *const SecretKeyType, msg: [*c]const u8, msg_len: usize, dst: [*c]const u8, dst_len: usize, aug: [*c]const u8, aug_len: usize) void {
+    return SecretKey.signC(out, sk, msg, msg_len, dst, dst_len, aug, aug_len);
+}
+
+export fn serializeSecretKey(out: *u8, sk: *const SecretKeyType) void {
+    return SecretKey.serializeSecretKey(out, sk);
+}
+
+export fn deserializeSecretKey(out: *SecretKeyType, sk_in: [*c]const u8, len: usize) c_uint {
+    return SecretKey.deserializeSecretKey(out, sk_in, len);
+}
+
+export fn secretKeyToBytes(out: *u8, sk: *const SecretKeyType) void {
+    return SecretKey.secretKeyToBytes(out, sk);
+}
+
+export fn secretKeyFromBytes(out: *SecretKeyType, sk_in: [*c]const u8, len: usize) c_uint {
+    return SecretKey.secretKeyFromBytes(out, sk_in, len);
 }
 
 test "test_sign_n_verify" {

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -327,6 +327,23 @@ export fn secretKeyFromBytes(out: *SecretKeyType, sk_in: [*c]const u8, len: usiz
     return SecretKey.secretKeyFromBytes(out, sk_in, len);
 }
 
+// MultiPoints functions
+export fn addPublicKeys(out: *AggregatePublicKeyType, pks: [*c]*const PublicKeyType, pks_len: usize) void {
+    return SigVariant.addPublicKeysC(out, pks, pks_len);
+}
+
+export fn multPublicKeys(out: *AggregatePublicKeyType, pks: [*c]*const PublicKeyType, pks_len: usize, scalars: [*c]*const u8, n_bits: usize, scratch: [*c]u64) void {
+    return SigVariant.multPublicKeysC(out, pks, pks_len, scalars, n_bits, scratch);
+}
+
+export fn addSignatures(out: *AggregateSignatureType, sigs: [*c]*const SignatureType, sigs_len: usize) void {
+    return SigVariant.addSignaturesC(out, sigs, sigs_len);
+}
+
+export fn multSignaturesC(out: *AggregateSignatureType, sigs: [*c]*const SignatureType, sigs_len: usize, scalars: [*c]*const u8, n_bits: usize, scratch: [*c]u64) void {
+    return SigVariant.multSignaturesC(out, sigs, sigs_len, scalars, n_bits, scratch);
+}
+
 test "test_sign_n_verify" {
     try SigVariant.testSignNVerify();
 }

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -232,6 +232,47 @@ export fn isSignatureEqual(point: *const SignatureType, other: *const SignatureT
     return Signature.isSignatureEqual(point, other);
 }
 
+/// AggregateSignatureType functions
+export fn defaultAggregateSignature(out: *AggregateSignatureType) void {
+    return AggregateSignature.defaultAggregateSignature(out);
+}
+
+export fn validateAggregateSignature(point: *const AggregateSignatureType) c_uint {
+    return AggregateSignature.validateAggregateSignature(point);
+}
+
+export fn aggregateFromSignature(out: *AggregateSignatureType, sig: *const SignatureType) void {
+    return AggregateSignature.aggregateFromSignature(out, sig);
+}
+
+export fn aggregateToSignature(out: *SignatureType, agg_sig: *const AggregateSignatureType) void {
+    return AggregateSignature.aggregateToSignature(out, agg_sig);
+}
+
+export fn aggregateSignatures(out: *AggregateSignatureType, sigs: [*c]*const SignatureType, len: usize, sigs_groupcheck: bool) c_uint {
+    return AggregateSignature.aggregateSignatures(out, sigs, len, sigs_groupcheck);
+}
+
+export fn aggregateSerialized(out: *AggregateSignatureType, sigs: [*c][*c]const u8, sigs_len: usize, sig_len: usize, sigs_groupcheck: bool) c_uint {
+    return AggregateSignature.aggregateSerializedC(out, sigs, sigs_len, sig_len, sigs_groupcheck);
+}
+
+export fn addAggregateC(out: *AggregateSignatureType, agg_sig: *const AggregateSignatureType) void {
+    return AggregateSignature.addAggregateC(out, agg_sig);
+}
+
+export fn addSignatureToAggregate(out: *AggregateSignatureType, sig: *const SignatureType, sig_groupcheck: bool) c_uint {
+    return AggregateSignature.addSignatureToAggregate(out, sig, sig_groupcheck);
+}
+
+export fn subgroupCheckC(agg_sig: *const AggregateSignatureType) bool {
+    return AggregateSignature.subgroupCheckC(agg_sig);
+}
+
+export fn isAggregateSignatureEqual(point: *const AggregateSignatureType, other: *const AggregateSignatureType) bool {
+    return AggregateSignature.isAggregateSignatureEqual(point, other);
+}
+
 test "test_sign_n_verify" {
     try SigVariant.testSignNVerify();
 }

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -70,14 +70,61 @@ const SigVariant = createSigVariant(
     c.blst_p2s_to_affine,
 );
 
-pub const min_pk = struct {
-    pub const PublicKey = SigVariant.createPublicKey();
-    pub const AggregatePublicKey = SigVariant.createAggregatePublicKey();
-    pub const Signature = SigVariant.createSignature();
-    pub const AggregateSignature = SigVariant.createAggregateSignature();
-    pub const SecretKey = SigVariant.createSecretKey();
-    pub const aggregateWithRandomness = SigVariant.aggregateWithRandomness;
-};
+pub const PublicKey = SigVariant.createPublicKey();
+pub const AggregatePublicKey = SigVariant.createAggregatePublicKey();
+pub const Signature = SigVariant.createSignature();
+pub const AggregateSignature = SigVariant.createAggregateSignature();
+pub const SecretKey = SigVariant.createSecretKey();
+pub const aggregateWithRandomness = SigVariant.aggregateWithRandomness;
+
+/// exported C-ABI functions need to be declared at top level, and they only work with extern struct
+const PublicKeyType = SigVariant.getPublicKeyType();
+const AggregatePublicKeyType = SigVariant.getAggregatePublicKeyType();
+
+/// PublicKey functions
+export fn defaultPublicKey() PublicKeyType {
+    return PublicKey.defaultPublicKey();
+}
+
+export fn validatePublicKey(pk: *const PublicKeyType) c_uint {
+    return PublicKey.validatePublicKey(pk);
+}
+
+export fn publicKeyBytesValidate(key: *const u8, len: usize) c_uint {
+    return PublicKey.publicKeyBytesValidate(key, len);
+}
+
+export fn fromAggregatePublicKey(out: *PublicKeyType, agg_pk: *const AggregatePublicKeyType) void {
+    return PublicKey.fromAggregatePublicKey(out, agg_pk);
+}
+
+export fn compressPublicKey(out: *u8, point: *const PublicKeyType) void {
+    return PublicKey.compressPublicKey(out, point);
+}
+
+export fn serializePublicKey(out: *u8, point: *const PublicKeyType) void {
+    return PublicKey.serializePublicKey(out, point);
+}
+
+export fn uncompressPublicKey(point: *PublicKeyType, pk_comp: *const u8, len: usize) c_uint {
+    return PublicKey.uncompressPublicKey(point, pk_comp, len);
+}
+
+export fn deserializePublicKey(point: *PublicKeyType, pk_in: *const u8, len: usize) c_uint {
+    return PublicKey.deserializePublicKey(point, pk_in, len);
+}
+
+export fn fromPublicKeyBytes(point: *PublicKeyType, pk_in: *const u8, len: usize) c_uint {
+    return PublicKey.fromPublicKeyBytes(point, pk_in, len);
+}
+
+export fn toPublicKeyBytes(out: *u8, point: *PublicKeyType) void {
+    return PublicKey.toPublicKeyBytes(out, point);
+}
+
+export fn isPublicKeyEqual(point: *PublicKeyType, other: *PublicKeyType) bool {
+    return PublicKey.isPublicKeyEqual(point, other);
+}
 
 test "test_sign_n_verify" {
     try SigVariant.testSignNVerify();

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -82,20 +82,20 @@ const PublicKeyType = SigVariant.getPublicKeyType();
 const AggregatePublicKeyType = SigVariant.getAggregatePublicKeyType();
 
 /// PublicKey functions
-export fn defaultPublicKey() PublicKeyType {
-    return PublicKey.defaultPublicKey();
+export fn defaultPublicKey(out: *PublicKeyType) void {
+    return PublicKey.defaultPublicKey(out);
 }
 
 export fn validatePublicKey(pk: *const PublicKeyType) c_uint {
     return PublicKey.validatePublicKey(pk);
 }
 
-export fn publicKeyBytesValidate(key: *const u8, len: usize) c_uint {
+export fn publicKeyBytesValidate(key: [*c]const u8, len: usize) c_uint {
     return PublicKey.publicKeyBytesValidate(key, len);
 }
 
-export fn fromAggregatePublicKey(out: *PublicKeyType, agg_pk: *const AggregatePublicKeyType) void {
-    return PublicKey.fromAggregatePublicKey(out, agg_pk);
+export fn publicKeyFromAggregate(out: *PublicKeyType, agg_pk: *const AggregatePublicKeyType) void {
+    return PublicKey.publicKeyFromAggregate(out, agg_pk);
 }
 
 export fn compressPublicKey(out: *u8, point: *const PublicKeyType) void {
@@ -106,16 +106,16 @@ export fn serializePublicKey(out: *u8, point: *const PublicKeyType) void {
     return PublicKey.serializePublicKey(out, point);
 }
 
-export fn uncompressPublicKey(point: *PublicKeyType, pk_comp: *const u8, len: usize) c_uint {
-    return PublicKey.uncompressPublicKey(point, pk_comp, len);
+export fn uncompressPublicKey(out: *PublicKeyType, pk_comp: [*c]const u8, len: usize) c_uint {
+    return PublicKey.uncompressPublicKey(out, pk_comp, len);
 }
 
-export fn deserializePublicKey(point: *PublicKeyType, pk_in: *const u8, len: usize) c_uint {
-    return PublicKey.deserializePublicKey(point, pk_in, len);
+export fn deserializePublicKey(out: *PublicKeyType, pk_in: [*c]const u8, len: usize) c_uint {
+    return PublicKey.deserializePublicKey(out, pk_in, len);
 }
 
-export fn fromPublicKeyBytes(point: *PublicKeyType, pk_in: *const u8, len: usize) c_uint {
-    return PublicKey.fromPublicKeyBytes(point, pk_in, len);
+export fn publicKeyFromBytes(point: *PublicKeyType, pk_in: [*c]const u8, len: usize) c_uint {
+    return PublicKey.publicKeyFromBytes(point, pk_in, len);
 }
 
 export fn toPublicKeyBytes(out: *u8, point: *PublicKeyType) void {
@@ -124,6 +124,43 @@ export fn toPublicKeyBytes(out: *u8, point: *PublicKeyType) void {
 
 export fn isPublicKeyEqual(point: *PublicKeyType, other: *PublicKeyType) bool {
     return PublicKey.isPublicKeyEqual(point, other);
+}
+
+/// AggregatePublicKeyType functions
+export fn defaultAggregatePublicKey(out: *AggregatePublicKeyType) void {
+    return AggregatePublicKey.defaultAggregatePublicKey(out);
+}
+
+export fn aggregateFromPublicKey(out: *AggregatePublicKeyType, pk: *const PublicKeyType) void {
+    return AggregatePublicKey.aggregateFromPublicKey(out, pk);
+}
+
+export fn aggregateToPublicKey(out: *PublicKeyType, agg_pk: *const AggregatePublicKeyType) void {
+    return AggregatePublicKey.aggregateToPublicKey(out, agg_pk);
+}
+
+export fn aggregatePublicKeys(out: *AggregatePublicKeyType, pks: [*c]*const PublicKeyType, len: usize, pks_validate: bool) c_uint {
+    return AggregatePublicKey.aggregatePublicKeys(out, pks, len, pks_validate);
+}
+
+export fn aggregateCompressedPublicKeys(out: *AggregatePublicKeyType, pks: [*c][*c]const u8, len: usize, pks_validate: bool) c_uint {
+    return AggregatePublicKey.aggregateCompressedPublicKeys(out, pks, len, pks_validate);
+}
+
+export fn aggregateSerializedPublicKeys(out: *AggregatePublicKeyType, pks: [*c][*c]const u8, len: usize, pks_validate: bool) c_uint {
+    return AggregatePublicKey.aggregateSerializedPublicKeys(out, pks, len, pks_validate);
+}
+
+export fn addAggregatePublicKey(out: *AggregatePublicKeyType, agg_pk: *const AggregatePublicKeyType) void {
+    return AggregatePublicKey.addAggregatePublicKey(out, agg_pk);
+}
+
+export fn addPublicKeyToAggregate(out: *AggregatePublicKeyType, pk: *const PublicKeyType, pk_validate: bool) c_uint {
+    return AggregatePublicKey.addPublicKeyToAggregate(out, pk, pk_validate);
+}
+
+export fn isAggregatePublicKeyEqual(agg_pk: *const AggregatePublicKeyType, other: *const AggregatePublicKeyType) bool {
+    return AggregatePublicKey.isAggregatePublicKeyEqual(agg_pk, other);
 }
 
 test "test_sign_n_verify" {

--- a/src/sig_variant_min_sig.zig
+++ b/src/sig_variant_min_sig.zig
@@ -70,14 +70,14 @@ const SigVariant = createSigVariant(
     c.blst_p1s_to_affine,
 );
 
-pub const min_sig = struct {
-    pub const PublicKey = SigVariant.createPublicKey();
-    pub const AggregatePublicKey = SigVariant.createAggregatePublicKey();
-    pub const Signature = SigVariant.createSignature();
-    pub const AggregateSignature = SigVariant.createAggregateSignature();
-    pub const SecretKey = SigVariant.createSecretKey();
-    pub const aggregateWithRandomness = SigVariant.aggregateWithRandomness;
-};
+pub const PublicKey = SigVariant.createPublicKey();
+pub const AggregatePublicKey = SigVariant.createAggregatePublicKey();
+pub const Signature = SigVariant.createSignature();
+pub const AggregateSignature = SigVariant.createAggregateSignature();
+pub const SecretKey = SigVariant.createSecretKey();
+pub const aggregateWithRandomness = SigVariant.aggregateWithRandomness;
+
+// TODO: sync exported C-ABI functions from min_pk
 
 test "test_sign_n_verify" {
     try SigVariant.testSignNVerify();


### PR DESCRIPTION
**Motivation**
- In preparation for Bun bindings, we need to export C-ABI functions from Zig

**Description**
- C-ABI functions need to be at top-level, and it's reffered from build.zig file
- it only works with extern structs, i.e. C structs
- refactor to let Zig functions to call C-ABI functions if possible. Some Zig functions have slice of slice so it's not possible to make code reusable, provide similar implementations instead
- make C-ABI compatible for Pairing and MultiPoint
- no Zig specific:
  - use C pointer [*c] instead of slice
  - provide extra `len` params
  - return error code instead of error union