### PR TITLE
fix: release flow for linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [x86_64-linux, aarch64-linux] # x86_64-macos, aarch64-macos,
+        platform: [x86_64-linux, aarch64-linux, x86_64-macos, aarch64-macos]
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Zig Build and Test
 on:
   push:
     branches:
-      - te/publish_built_files
+      - origin/te/publish_built_files_linux
 
 jobs:
   build-and-test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,11 +69,15 @@ jobs:
 
       - name: Set shared library extension
         id: set_extension
-        run: echo "ext=$([[ ${{ matrix.platform }} == 'x86_64-linux' ]] && echo 'so' || [[ ${{ matrix.platform }} == 'aarch64-linux' ]] && echo 'so' || echo 'dylib')" >> $GITHUB_ENV
+        run: |
+          case "${{ matrix.platform }}" in
+            x86_64-linux|aarch64-linux) echo "EXT=so" >> $GITHUB_ENV ;;
+            *) echo "EXT=dylib" >> $GITHUB_ENV ;;
+          esac
 
       - name: Upload shared library artifact for ${{ matrix.platform }}
         uses: actions/upload-artifact@v4
         with:
-          name: libblst_min_pk_${{ matrix.platform }}.${{ env.ext }}
-          path: zig-out/lib/libblst_min_pk.${{ env.ext }}
+          name: libblst_min_pk_${{ matrix.platform }}.${{ env.EXT }}
+          path: zig-out/lib/libblst_min_pk.${{ env.EXT }}
           compression-level: 0 # No compression

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build blst-z on ${{ matrix.platform }}
         run: |
-          zig build zig build --verbose --verbose-link -Dtarget=${{ matrix.platform }}
+          zig build --verbose --verbose-link -Dtarget=${{ matrix.platform }}
 
       - name: Upload static library artifact for ${{ matrix.platform }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Zig Build and Test
 on:
   push:
     branches:
-      - origin/te/publish_built_files_linux
+      - te/publish_built_files_linux
 
 jobs:
   build-and-test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [x86_64-macos, aarch64-macos, x86_64-linux, aarch64-linux]
+        platform: [x86_64-linux] # x86_64-macos, aarch64-macos, aarch64-linux
 
     steps:
       - name: Checkout Repository
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build blst-z on ${{ matrix.platform }}
         run: |
-          zig build -Dtarget=${{ matrix.platform }}
+          zig build -Dtarget=${{ matrix.platform }} test
 
       - name: Upload static library artifact for ${{ matrix.platform }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Build blst on host
         run: |
           cd blst
-          zig cc -target x86_64-linux -c src/server.c -o server.o
-          zig cc -target x86_64-linux -c build/assembly.S -o assembly.o
+          zig cc -fno-builtin -fPIC -target x86_64-linux -c src/server.c -o server.o
+          zig cc -fno-builtin -fPIC -target x86_64-linux -c build/assembly.S -o assembly.o
           zig ar rcs libblst.a server.o assembly.o
 
       - name: Verify built blst on host
@@ -48,8 +48,8 @@ jobs:
         run: |
           cd blst
           rm -f libblst.a
-          zig cc -target ${{ matrix.platform }} -c src/server.c -o server.o
-          zig cc -target ${{ matrix.platform }} -c build/assembly.S -o assembly.o
+          zig cc -fno-builtin -fPIC -target ${{ matrix.platform }} -c src/server.c -o server.o
+          zig cc -fno-builtin -fPIC -target ${{ matrix.platform }} -c build/assembly.S -o assembly.o
           zig ar rcs libblst.a server.o assembly.o
 
       - name: Verify built blst on ${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build blst-z on ${{ matrix.platform }}
         run: |
-          zig build --verbose --verbose-link -Dtarget=${{ matrix.platform }}
+          zig build -Dtarget=${{ matrix.platform }}
 
       - name: Upload static library artifact for ${{ matrix.platform }}
         uses: actions/upload-artifact@v4
@@ -71,5 +71,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: libblst_min_pk_${{ matrix.platform }}.dylib
-          path: zig-out/lib/libblst_min_pk.dylib
+          path: zig-out/lib/libblst_min_pk.so
           compression-level: 0 # No compression

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,9 +67,13 @@ jobs:
           path: zig-out/lib/libblst.a
           compression-level: 0 # No compression
 
+      - name: Set shared library extension
+        id: set_extension
+        run: echo "ext=$([[ ${{ matrix.platform }} == 'x86_64-linux' ]] && echo 'so' || [[ ${{ matrix.platform }} == 'aarch64-linux' ]] && echo 'so' || echo 'dylib')" >> $GITHUB_ENV
+
       - name: Upload shared library artifact for ${{ matrix.platform }}
         uses: actions/upload-artifact@v4
         with:
-          name: libblst_min_pk_${{ matrix.platform }}.dylib
-          path: zig-out/lib/libblst_min_pk.so
+          name: libblst_min_pk_${{ matrix.platform }}.${{ env.ext }}
+          path: zig-out/lib/libblst_min_pk.${{ env.ext }}
           compression-level: 0 # No compression

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build blst-z on ${{ matrix.platform }}
         run: |
-          zig build -Dtarget=${{ matrix.platform }} test
+          zig build -Dtarget=${{ matrix.platform }}
 
       - name: Upload static library artifact for ${{ matrix.platform }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [x86_64-linux] # x86_64-macos, aarch64-macos, aarch64-linux
+        platform: [x86_64-linux, aarch64-linux] # x86_64-macos, aarch64-macos,
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build blst-z on ${{ matrix.platform }}
         run: |
-          zig build -Dtarget=${{ matrix.platform }}
+          zig build zig build --verbose --verbose-link -Dtarget=${{ matrix.platform }}
 
       - name: Upload static library artifact for ${{ matrix.platform }}
         uses: actions/upload-artifact@v4

--- a/build.zig
+++ b/build.zig
@@ -27,7 +27,6 @@ pub fn build(b: *std.Build) !void {
 
     // TODO: build.bat for windows
 
-    // TODO: may need to build this manually for development flow, on release.yml it's built by "zig cc"
     const blst_file_path = "blst/libblst.a";
     const fs = std.fs.cwd();
     const file_exist = blk: {
@@ -62,8 +61,6 @@ pub fn build(b: *std.Build) !void {
         .target = target,
         .optimize = optimize,
     });
-    // On Linux, shared libraries must be compiled with -fPIC
-    sharedLib.pie = true;
     sharedLib.addObjectFile(b.path(blst_file_path));
     sharedLib.addIncludePath(b.path("blst/bindings"));
     b.installArtifact(sharedLib);

--- a/build.zig
+++ b/build.zig
@@ -27,6 +27,7 @@ pub fn build(b: *std.Build) !void {
 
     // TODO: build.bat for windows
 
+    // TODO: may need to build this manually for development flow, on release.yml it's built by "zig cc"
     const blst_file_path = "blst/libblst.a";
     const fs = std.fs.cwd();
     const file_exist = blk: {
@@ -61,6 +62,8 @@ pub fn build(b: *std.Build) !void {
         .target = target,
         .optimize = optimize,
     });
+    // On Linux, shared libraries must be compiled with -fPIC
+    sharedLib.pie = true;
     sharedLib.addObjectFile(b.path(blst_file_path));
     sharedLib.addIncludePath(b.path("blst/bindings"));
     b.installArtifact(sharedLib);


### PR DESCRIPTION
**Description**
- Fix build on linux:
  - add `-fno-builtin -fPIC` flag, refer to `build.sh` of blst
  - different shared library extension for linux vs macos