### PR TITLE
feat: integrate blst build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,36 +29,13 @@ jobs:
         with:
           version: "0.13.0" # Set the required Zig version
 
-      - name: Build blst on host
-        run: |
-          cd blst
-          zig cc -fno-builtin -fPIC -target x86_64-linux -c src/server.c -o server.o
-          zig cc -fno-builtin -fPIC -target x86_64-linux -c build/assembly.S -o assembly.o
-          zig ar rcs libblst.a server.o assembly.o
-
-      - name: Verify built blst on host
-        run: |
-          ls -la blst/libblst.a
-
       - name: Build and test blst-z on host
         run: |
-          zig build test
-
-      - name: Build blst on ${{ matrix.platform }}
-        run: |
-          cd blst
-          rm -f libblst.a
-          zig cc -fno-builtin -fPIC -target ${{ matrix.platform }} -c src/server.c -o server.o
-          zig cc -fno-builtin -fPIC -target ${{ matrix.platform }} -c build/assembly.S -o assembly.o
-          zig ar rcs libblst.a server.o assembly.o
-
-      - name: Verify built blst on ${{ matrix.platform }}
-        run: |
-          ls -la blst/libblst.a
+          zig build -Dportable=true test
 
       - name: Build blst-z on ${{ matrix.platform }}
         run: |
-          zig build -Dtarget=${{ matrix.platform }}
+          zig build -Dtarget=${{ matrix.platform }} -Dportable=true -Doptimize=ReleaseFast
 
       - name: Upload static library artifact for ${{ matrix.platform }}
         uses: actions/upload-artifact@v4

--- a/build.zig
+++ b/build.zig
@@ -189,7 +189,9 @@ fn withBlst(b: *std.Build, blst_z_lib: *Compile, is_shared_lib: bool, portable: 
 
     if (arch == .x86_64 or arch == .aarch64) {
         std.debug.print("Adding assembly file {} \n", .{arch});
-        blst_z_lib.addAssemblyFile(b.path("blst/build/assembly.S"));
+        // this only works with compiled assembly file
+        // blst_z_lib.addAssemblyFile(b.path("blst/build/assembly.S"));
+        blst_z_lib.addCSourceFile(.{ .file = b.path("blst/build/assembly.S"), .flags = cflags.items });
     } else {
         std.debug.print("Do not add assembly file {} \n", .{arch});
         blst_z_lib.defineCMacro("__BLST_NO_ASM__", "");

--- a/build.zig
+++ b/build.zig
@@ -201,7 +201,7 @@ fn withBlst(b: *std.Build, blst_z_lib: *Compile, target: ResolvedTarget, optimiz
         });
 
         std.debug.print("Adding compiled assembly file {} \n", .{arch});
-        assembly_obj.addCSourceFile(.{ .file = b.path("blst/build/assembly.S"), .flags = cflags.items });
+        assembly_obj.addCSourceFile(.{ .file = b.path("blst/build/assembly.S") });
         // link the compiled assembly file
         blst_z_lib.addObject(assembly_obj);
     } else {

--- a/build.zig
+++ b/build.zig
@@ -177,7 +177,9 @@ fn withBlst(b: *std.Build, blst_z_lib: *Compile, target: ResolvedTarget, optimiz
     defer cflags.deinit();
 
     // get this error in Mac arm: unsupported option '-mno-avx' for target 'aarch64-unknown-macosx15.1.0-unknown'
-    // try cflags.append("-mno-avx"); // avoid costly transitions
+    if (arch == .x86_64) {
+        try cflags.append("-mno-avx"); // avoid costly transitions
+    }
     // the no_builtin should help, set here just to make sure
     try cflags.append("-fno-builtin");
     try cflags.append("-Wno-unused-function");

--- a/build.zig
+++ b/build.zig
@@ -147,13 +147,6 @@ fn withBlst(b: *std.Build, blst_z_lib: *Compile, is_shared_lib: bool, portable: 
     // add later, once we have cflags
     // blst_z_lib.addCSourceFile(b.path("blst/src/server.c"));
     const arch = target.cpu.arch;
-    if (arch == .x86_64 or arch == .aarch64) {
-        std.debug.print("Adding assembly file {} \n", .{arch});
-        blst_z_lib.addAssemblyFile(b.path("blst/build/assembly.S"));
-    } else {
-        std.debug.print("Do not add assembly file {} \n", .{arch});
-        blst_z_lib.defineCMacro("__BLST_NO_ASM__", "");
-    }
 
     // TODO: how to get target_env?
     // TODO: may have a separate build version for adx
@@ -193,6 +186,14 @@ fn withBlst(b: *std.Build, blst_z_lib: *Compile, is_shared_lib: bool, portable: 
     }
 
     blst_z_lib.addCSourceFile(.{ .file = b.path("blst/src/server.c"), .flags = cflags.items });
+
+    if (arch == .x86_64 or arch == .aarch64) {
+        std.debug.print("Adding assembly file {} \n", .{arch});
+        blst_z_lib.addAssemblyFile(b.path("blst/build/assembly.S"));
+    } else {
+        std.debug.print("Do not add assembly file {} \n", .{arch});
+        blst_z_lib.defineCMacro("__BLST_NO_ASM__", "");
+    }
 
     // fix this error on Linux: 'stdlib.h' file not found
     // zig cc -E -Wp,-v -

--- a/build.zig
+++ b/build.zig
@@ -52,7 +52,7 @@ pub fn build(b: *std.Build) !void {
     // passed by "zig build -Dforce-adx"
     const force_adx = b.option(bool, "force-adx", "Enable ADX optimizations") orelse false;
 
-    try addBlst(b, staticLib, false, portable, force_adx);
+    try withBlst(b, staticLib, false, portable, force_adx);
 
     // the folder where blst.h is located
     staticLib.addIncludePath(b.path("blst/bindings"));
@@ -70,7 +70,7 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     });
     // sharedLib.addObjectFile(b.path(blst_file_path));
-    try addBlst(b, sharedLib, true, portable, force_adx);
+    try withBlst(b, sharedLib, true, portable, force_adx);
     sharedLib.addIncludePath(b.path("blst/bindings"));
     b.installArtifact(sharedLib);
 
@@ -140,7 +140,7 @@ pub fn build(b: *std.Build) !void {
     test_step.dependOn(&run_exe_unit_tests.step);
 }
 
-fn addBlst(b: *std.Build, blst_z_lib: *Compile, is_shared_lib: bool, portable: bool, force_adx: bool) !void {
+fn withBlst(b: *std.Build, blst_z_lib: *Compile, is_shared_lib: bool, portable: bool, force_adx: bool) !void {
     const target = blst_z_lib.rootModuleTarget();
     // const optimize = blst_z_lib.root_module.optimize;
 
@@ -148,8 +148,10 @@ fn addBlst(b: *std.Build, blst_z_lib: *Compile, is_shared_lib: bool, portable: b
     // blst_z_lib.addCSourceFile(b.path("blst/src/server.c"));
     const arch = target.cpu.arch;
     if (arch == .x86_64 or arch == .aarch64) {
+        std.debug.print("Adding assembly file {} \n", .{arch});
         blst_z_lib.addAssemblyFile(b.path("blst/build/assembly.S"));
     } else {
+        std.debug.print("Do not add assembly file {} \n", .{arch});
         blst_z_lib.defineCMacro("__BLST_NO_ASM__", "");
     }
 

--- a/build.zig
+++ b/build.zig
@@ -191,4 +191,13 @@ fn addBlst(b: *std.Build, blst_z_lib: *Compile, is_shared_lib: bool, portable: b
     }
 
     blst_z_lib.addCSourceFile(.{ .file = b.path("blst/src/server.c"), .flags = cflags.items });
+
+    // fix this error on Linux: 'stdlib.h' file not found
+    // zig cc -E -Wp,-v -
+    // /usr/local/include
+    //  /usr/include/x86_64-linux-gnu
+    //  /usr/include
+    blst_z_lib.addIncludePath(.{ .cwd_relative = "/usr/local/include" });
+    blst_z_lib.addIncludePath(.{ .cwd_relative = "/usr/include/x86_64-linux-gnu" });
+    blst_z_lib.addIncludePath(.{ .cwd_relative = "/usr/include" });
 }


### PR DESCRIPTION
**Motivation**
- right now we treat blst as a dependency lib, we build it first and link it on `build.zig`
- the build workflow in `build.zig` is different from the release CI (`build.sh` vs `zig cc`)
- also we did not support windows

**Description**
- treat blst as an intergrated part, our libs will contain both zig code and C code and assembly code
- use different flags for different platform, this will help us support more platforms in the future. See https://github.com/supranational/blst/blob/v0.3.13/bindings/rust/build.rs