### PR TITLE
feat: run CI on different platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,19 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [x86_64-linux, aarch64-linux, x86_64-macos, aarch64-macos]
+        settings:
+          - os: ubuntu-latest
+            platform: x86_64-linux
+          - os: ubuntu-24.04-arm
+            platform: aarch64-linux
+          - os: macos-13
+            platform: x86_64-macos
+          - os: macos-latest
+            platform: aarch64-macos
 
+    runs-on: ${{ matrix.settings.os }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -33,29 +41,29 @@ jobs:
         run: |
           zig build -Dportable=true test
 
-      - name: Build blst-z on ${{ matrix.platform }}
+      - name: Build blst-z on ${{ matrix.settings.platform }}
         run: |
-          zig build -Dtarget=${{ matrix.platform }} -Dportable=true -Doptimize=ReleaseFast
+          zig build -Dtarget=${{ matrix.settings.platform }} -Dportable=true -Doptimize=ReleaseFast
 
-      - name: Upload static library artifact for ${{ matrix.platform }}
+      - name: Upload static library artifact for ${{ matrix.settings.platform }}
         uses: actions/upload-artifact@v4
         with:
-          name: libblst_${{ matrix.platform }}.a
+          name: libblst_${{ matrix.settings.platform }}.a
           path: zig-out/lib/libblst.a
           compression-level: 0 # No compression
 
       - name: Set shared library extension
         id: set_extension
         run: |
-          case "${{ matrix.platform }}" in
+          case "${{ matrix.settings.platform }}" in
             x86_64-linux|aarch64-linux) echo "EXT=so" >> $GITHUB_ENV ;;
             *) echo "EXT=dylib" >> $GITHUB_ENV ;;
           esac
 
-      - name: Upload shared library artifact for ${{ matrix.platform }}
+      - name: Upload shared library artifact for ${{ matrix.settings.platform }}
         uses: actions/upload-artifact@v4
         with:
-          name: libblst_min_pk_${{ matrix.platform }}.${{ env.EXT }}
+          name: libblst_min_pk_${{ matrix.settings.platform }}.${{ env.EXT }}
           path: zig-out/lib/libblst_min_pk.${{ env.EXT }}
           compression-level: 0 # No compression
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build blst-z on ${{ matrix.settings.platform }}
         run: |
-          zig build -Dtarget=${{ matrix.settings.platform }} -Dportable=true -Doptimize=ReleaseFast
+          zig build -Dtarget=${{ matrix.settings.platform }} -Dportable=true -Doptimize=ReleaseSafe
 
       - name: Upload static library artifact for ${{ matrix.settings.platform }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,28 +10,37 @@ on:
 
 jobs:
   zig-build-test:
-    runs-on: ubuntu-latest
+    # runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        settings:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+          - os: macos-13
+            arch: x86_64
+          - os: macos-latest
+            arch: aarch64
+
+    runs-on: ${{ matrix.settings.os }}
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive # Ensures submodules are cloned
           fetch-depth: 0        # Fetches the entire history for all branches
+
+      - name: Print OS ${{ matrix.settings.os }}
+        run: uname -a
+      - name: Print Architecture ${{ matrix.settings.arch }}
+        run: uname -m
 
       - name: Verify Submodules
         run: |
           git submodule update --init --recursive
           ls -la blst
-
-      - name: Run blst/build.sh
-        run: |
-          cd blst
-          ./build.sh
-
-      - name: Verify built blst
-        run: |
-          ls -la blst/libblst.a
 
       - name: Install Zig
         uses: mlugg/setup-zig@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   zig-build-test:
-    # runs-on: ubuntu-latest
     strategy:
       matrix:
         settings:

--- a/build.zig
+++ b/build.zig
@@ -179,13 +179,17 @@ fn withBlst(b: *std.Build, blst_z_lib: *Compile, target: ResolvedTarget, is_shar
     blst_z_lib.addCSourceFile(.{ .file = b.path("blst/src/server.c"), .flags = cflags.items });
     blst_z_lib.addCSourceFile(.{ .file = b.path("blst/build/assembly.S"), .flags = cflags.items });
 
+    const os = target.result.os;
     // fix this error on Linux: 'stdlib.h' file not found
-    // since "zig cc" works fine, we just follow it
-    // zig cc -E -Wp,-v -
-    //   /usr/local/include
-    //   /usr/include/x86_64-linux-gnu
-    //   /usr/include
-    blst_z_lib.addIncludePath(.{ .cwd_relative = "/usr/local/include" });
-    blst_z_lib.addIncludePath(.{ .cwd_relative = "/usr/include/x86_64-linux-gnu" });
-    blst_z_lib.addIncludePath(.{ .cwd_relative = "/usr/include" });
+    if (os.tag == .linux) {
+        // since "zig cc" works fine, we just follow it
+        // zig cc -E -Wp,-v -
+        blst_z_lib.addIncludePath(.{ .cwd_relative = "/usr/local/include" });
+        blst_z_lib.addIncludePath(.{ .cwd_relative = "/usr/include" });
+        if (arch == .x86_64) {
+            blst_z_lib.addIncludePath(.{ .cwd_relative = "/usr/include/x86_64-linux-gnu" });
+        } else if (arch == .aarch64) {
+            blst_z_lib.addIncludePath(.{ .cwd_relative = "/usr/include/aarch64-linux-gnu" });
+        }
+    }
 }


### PR DESCRIPTION
- the previous PR #21 build both original blst and zig code in the same lib. It added platform dependent include paths
- so `release.yml` needs to be run on different platform, same to `test.yml`
- fix include path for Linux `aarch64`