### PR TITLE
fix: build artifact on native host without target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,13 @@ jobs:
         with:
           version: "0.13.0" # Set the required Zig version
 
-      - name: Build and test blst-z on host
+      - name: Test blst-z
         run: |
           zig build -Dportable=true test
 
       - name: Build blst-z on ${{ matrix.settings.platform }}
         run: |
-          zig build -Dtarget=${{ matrix.settings.platform }} -Dportable=true -Doptimize=ReleaseSafe
+          zig build -Dportable=true -Doptimize=ReleaseSafe
 
       - name: Upload static library artifact for ${{ matrix.settings.platform }}
         uses: actions/upload-artifact@v4

--- a/build.zig
+++ b/build.zig
@@ -185,6 +185,7 @@ fn withBlst(b: *std.Build, blst_z_lib: *Compile, target: ResolvedTarget, is_shar
     blst_z_lib.addCSourceFile(.{ .file = b.path("blst/src/server.c"), .flags = cflags.items });
     blst_z_lib.addCSourceFile(.{ .file = b.path("blst/build/assembly.S"), .flags = cflags.items });
 
+    // TODO: we may not need this since we linkLibC() above
     const os = target.result.os;
     // fix this error on Linux: 'stdlib.h' file not found
     // otherwise blst-bun cannot load the shared library on Linux


### PR DESCRIPTION
**Motivation**
- cannot load the released artifacts on blst-bun / Linux

**Description**
- I tested on my Linux host that if I build blst-z without "-Dtarget" then it works fine
- in `release.yml`, we build artifacts on target platform already so no need "-Dtarget"