### PR TITLE
feat: implement MemoryPool for aggregateWithRandomness functions

### DIFF
--- a/src/memory_pool.zig
+++ b/src/memory_pool.zig
@@ -1,0 +1,146 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const c = @cImport({
+    @cInclude("blst.h");
+});
+
+var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+
+// for min_pk, it's  c.blst_p1s_mult_pippenger_scratch_sizeof function
+const PkScratchSizeOfFn = *const fn (npoints: usize) callconv(.C) usize;
+// for min_pk, it's c.blst_p2s_mult_pippenger_scratch_sizeof function
+const SigScratchSizeOfFn = *const fn (npoints: usize) callconv(.C) usize;
+
+const U8ArrayArray = std.ArrayList([]u8);
+
+/// for some apis, for example, aggregateWithRandomness, we have to allocate pk_scratch and sig_scratch buffer
+/// since these are not constant, we need to allocate them dynamically
+/// due to Zig not having a gc, it's reasonable to have a memory pool so that we can reuse the memory if needed
+/// this implementation assumes an application only go with either min_pk or min_sig
+pub fn createMemoryPool(comptime scratch_in_batch: usize, comptime pk_scratch_sizeof_fn: PkScratchSizeOfFn, comptime sig_scratch_sizeof_fn: SigScratchSizeOfFn) type {
+    const MemoryPool = struct {
+        // aggregateWithRandomness api, application decides number of signatures/publickeys to aggregate in batch
+        // for Bun, it's 128
+        pk_scratch_arr: U8ArrayArray,
+        sig_scratch_arr: U8ArrayArray,
+        allocator: Allocator,
+
+        pub fn init(in_allocator: ?Allocator) !@This() {
+            const allocator = in_allocator orelse gpa.allocator();
+            return @This(){
+                .pk_scratch_arr = try U8ArrayArray.initCapacity(allocator, 0),
+                .sig_scratch_arr = try U8ArrayArray.initCapacity(allocator, 0),
+                .allocator = allocator,
+            };
+        }
+
+        pub fn deinit(self: *@This()) void {
+            // free all the scratch buffers
+            for (self.pk_scratch_arr.items) |pk_scratch| {
+                self.allocator.free(pk_scratch);
+            }
+            self.pk_scratch_arr.deinit();
+
+            for (self.sig_scratch_arr.items) |sig_scratch| {
+                self.allocator.free(sig_scratch);
+            }
+            self.sig_scratch_arr.deinit();
+        }
+
+        pub fn getPublicKeyScratch(self: *@This()) ![]u8 {
+            const pk_scratch_size = pk_scratch_sizeof_fn(scratch_in_batch);
+            if (self.pk_scratch_arr.items.len == 0) {
+                // allocate new
+                return try self.allocator.alloc(u8, pk_scratch_size);
+            }
+
+            // reuse last
+            const last_scratch = self.pk_scratch_arr.pop();
+            if (last_scratch.len != pk_scratch_size) {
+                // this should not happen
+                return error.InvalidScratchSize;
+            }
+            return last_scratch;
+        }
+
+        pub fn getSignatureScratch(self: *@This()) ![]u8 {
+            const sig_scratch_size = sig_scratch_sizeof_fn(scratch_in_batch);
+            if (self.sig_scratch_arr.items.len == 0) {
+                // allocate new
+                return try self.allocator.alloc(u8, sig_scratch_size);
+            }
+
+            // reuse last
+            const last_scratch = self.sig_scratch_arr.pop();
+            if (last_scratch.len != sig_scratch_size) {
+                // this should not happen
+                return error.InvalidScratchSize;
+            }
+            return last_scratch;
+        }
+
+        pub fn returnPublicKeyScratch(self: *@This(), scratch: []u8) !void {
+            const pk_scratch_size = pk_scratch_sizeof_fn(scratch_in_batch);
+            if (scratch.len != pk_scratch_size) {
+                // this should not happen
+                return error.InvalidScratchSize;
+            }
+
+            // return the scratch to the pool
+            try self.pk_scratch_arr.append(scratch);
+        }
+
+        pub fn returnSignatureScratch(self: *@This(), scratch: []u8) !void {
+            const sig_scratch_size = sig_scratch_sizeof_fn(scratch_in_batch);
+            if (scratch.len != sig_scratch_size) {
+                // this should not happen
+                return error.InvalidScratchSize;
+            }
+
+            // return the scratch to the pool
+            try self.sig_scratch_arr.append(scratch);
+        }
+    };
+
+    return MemoryPool;
+}
+
+test "memory pool - public key scratch" {
+    const scratch_in_batch = 128;
+    const MemoryPool = createMemoryPool(scratch_in_batch, c.blst_p1s_mult_pippenger_scratch_sizeof, c.blst_p2s_mult_pippenger_scratch_sizeof);
+    const allocator = std.testing.allocator;
+    var pool = try MemoryPool.init(allocator);
+    defer pool.deinit();
+    try std.testing.expect(pool.pk_scratch_arr.items.len == 0);
+    // allocate new
+    var pk_scratch_0 = try pool.getPublicKeyScratch();
+    try std.testing.expect(pool.pk_scratch_arr.items.len == 0);
+    try pool.returnPublicKeyScratch(pk_scratch_0);
+    try std.testing.expect(pool.pk_scratch_arr.items.len == 1);
+
+    // reuse
+    pk_scratch_0 = try pool.getPublicKeyScratch();
+    // no need to allocate again
+    try std.testing.expect(pool.pk_scratch_arr.items.len == 0);
+    defer allocator.free(pk_scratch_0);
+}
+
+test "memory pool - signature scratch" {
+    const scratch_in_batch = 128;
+    const MemoryPool = createMemoryPool(scratch_in_batch, c.blst_p1s_mult_pippenger_scratch_sizeof, c.blst_p2s_mult_pippenger_scratch_sizeof);
+    const allocator = std.testing.allocator;
+    var pool = try MemoryPool.init(allocator);
+    defer pool.deinit();
+    try std.testing.expect(pool.sig_scratch_arr.items.len == 0);
+    // allocate new
+    var sig_scratch_0 = try pool.getSignatureScratch();
+    try std.testing.expect(pool.sig_scratch_arr.items.len == 0);
+    try pool.returnSignatureScratch(sig_scratch_0);
+    try std.testing.expect(pool.sig_scratch_arr.items.len == 1);
+
+    // reuse
+    sig_scratch_0 = try pool.getSignatureScratch();
+    // no need to allocate again
+    try std.testing.expect(pool.sig_scratch_arr.items.len == 0);
+    defer allocator.free(sig_scratch_0);
+}

--- a/src/memory_pool.zig
+++ b/src/memory_pool.zig
@@ -4,10 +4,7 @@ const c = @cImport({
     @cInclude("blst.h");
 });
 
-// for min_pk, it's  c.blst_p1s_mult_pippenger_scratch_sizeof function
-const PkScratchSizeOfFn = *const fn (npoints: usize) callconv(.C) usize;
-// for min_pk, it's c.blst_p2s_mult_pippenger_scratch_sizeof function
-const SigScratchSizeOfFn = *const fn (npoints: usize) callconv(.C) usize;
+const ScratchSizeOfFn = *const fn (npoints: usize) callconv(.C) usize;
 
 const U64SliceArray = std.ArrayList([]u64);
 
@@ -15,7 +12,9 @@ const U64SliceArray = std.ArrayList([]u64);
 /// since these are not constant, we need to allocate them dynamically
 /// due to Zig not having a gc, it's reasonable to have a memory pool so that we can reuse the memory if needed
 /// this implementation assumes an application only go with either min_pk or min_sig
-pub fn createMemoryPool(comptime scratch_in_batch: usize, comptime pk_scratch_sizeof_fn: PkScratchSizeOfFn, comptime sig_scratch_sizeof_fn: SigScratchSizeOfFn) type {
+/// pk_scratch_sizeof_fn: it's c.blst_p1s_mult_pippenger_scratch_sizeof function for min_pk
+/// sig_scratch_sizeof_fn: it's c.blst_p2s_mult_pippenger_scratch_sizeof function for min_sig
+pub fn createMemoryPool(comptime scratch_in_batch: usize, comptime pk_scratch_sizeof_fn: ScratchSizeOfFn, comptime sig_scratch_sizeof_fn: ScratchSizeOfFn) type {
     const MemoryPool = struct {
         // aggregateWithRandomness api, application decides number of signatures/publickeys to aggregate in batch
         // for Bun, it's 128

--- a/src/root.zig
+++ b/src/root.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const testing = std.testing;
 pub const min_pk_sig_variant = @import("./sig_variant_min_pk.zig");
 pub const min_sig_sig_variant = @import("./sig_variant_min_sig.zig");
+pub const createMemoryPool = @import("./memory_pool.zig").createMemoryPool;
+pub const initializeThreadPool = @import("./thread_pool.zig").initializeThreadPool;
 
 pub const min_pk = struct {
     pub const PublicKey = min_pk_sig_variant.PublicKey;

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 const testing = std.testing;
 const Xoshiro256 = std.rand.Xoshiro256;
 const Pairing = @import("./pairing.zig").Pairing;
@@ -93,6 +94,7 @@ const SecretKeyType = SigVariant.getSecretKeyType();
 const SignatureSetType = SigVariant.getSignatureSetType();
 const PkAndSerializedSigType = SigVariant.getPkAndSerializedSigType();
 const CallBackFn = SigVariant.getCallBackFn();
+const MemoryPool = SigVariant.getMemoryPoolType();
 
 /// PublicKey functions
 export fn defaultPublicKey() PublicKeyType {
@@ -394,32 +396,50 @@ export fn sizeOfPairing() c_uint {
     return @intCast(Pairing.sizeOf());
 }
 
-export fn aggregateWithRandomness(sets: [*c]*const PkAndSerializedSigType, sets_len: c_uint, pk_scratch_u8: [*c]u8, pk_scratch_len: c_uint, sig_scratch_u8: [*c]u8, sig_scratch_len: c_uint, pk_out: *PublicKeyType, sig_out: *SignatureType) c_uint {
-    return SigVariant.aggregateWithRandomnessC(sets, sets_len, pk_scratch_u8, pk_scratch_len, sig_scratch_u8, sig_scratch_len, pk_out, sig_out, null);
+threadlocal var memory_pool: ?*MemoryPool = null;
+var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+
+/// this is supposed to be called from the main thread so we dont need mutex here
+fn getMemoryPool(in_allocator: ?Allocator) !*MemoryPool {
+    if (memory_pool) |pool| {
+        return pool;
+    }
+    const allocator = in_allocator orelse gpa.allocator();
+    var mem_pool = try allocator.create(MemoryPool);
+    try mem_pool.init(allocator);
+    memory_pool = mem_pool;
+    return mem_pool;
 }
 
-export fn asyncAggregateWithRandomness(sets: [*c]*const PkAndSerializedSigType, sets_len: c_uint, pk_scratch_u8: [*c]u8, pk_scratch_len: c_uint, sig_scratch_u8: [*c]u8, sig_scratch_len: c_uint, pk_out: *PublicKeyType, sig_out: *SignatureType, callback: CallBackFn) c_uint {
-    return SigVariant.asyncAggregateWithRandomness(sets, sets_len, pk_scratch_u8, pk_scratch_len, sig_scratch_u8, sig_scratch_len, pk_out, sig_out, callback);
+// TODO: implement equivalent api for zig application with allocator param
+export fn aggregateWithRandomness(sets: [*c]*const PkAndSerializedSigType, sets_len: c_uint, pk_out: *PublicKeyType, sig_out: *SignatureType) c_uint {
+    const pool = getMemoryPool(null) catch return c.BLST_BAD_ENCODING;
+    const res = SigVariant.aggregateWithRandomnessC(sets, sets_len, pool, pk_out, sig_out, null);
+    return res;
+}
+
+// TODO: implement equivalent api for zig application with allocator param
+export fn asyncAggregateWithRandomness(sets: [*c]*const PkAndSerializedSigType, sets_len: c_uint, pk_out: *PublicKeyType, sig_out: *SignatureType, callback: CallBackFn) c_uint {
+    const pool = getMemoryPool(null) catch return c.BLST_BAD_ENCODING;
+    return SigVariant.asyncAggregateWithRandomness(sets, sets_len, pool, pk_out, sig_out, callback);
 }
 
 /// a Bun application should call this before using any of the exported functions
 export fn init() c_uint {
     initializeThreadPool(null) catch return c.BLST_BAD_ENCODING;
+    // this is optional to do, we may lazy init it
+    _ = getMemoryPool(null) catch return c.BLST_BAD_ENCODING;
     return c.BLST_SUCCESS;
 }
 
 /// a Bun application should call this after using any of the exported functions
 export fn deinit() void {
     deinitializeThreadPool();
-}
-
-// this returns size in u8
-export fn sizeOfScratchPk(num_pks: usize) usize {
-    return c.blst_p1s_mult_pippenger_scratch_sizeof(num_pks);
-}
-
-export fn sizeOfScratchSig(num_sigs: usize) usize {
-    return c.blst_p2s_mult_pippenger_scratch_sizeof(num_sigs);
+    if (memory_pool) |pool| {
+        const allocator = pool.allocator;
+        pool.deinit();
+        allocator.destroy(pool);
+    }
 }
 
 test "test_sign_n_verify" {

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -411,16 +411,26 @@ fn getMemoryPool(in_allocator: ?Allocator) !*MemoryPool {
     return mem_pool;
 }
 
-// TODO: implement equivalent api for zig application with allocator param
 export fn aggregateWithRandomness(sets: [*c]*const PkAndSerializedSigType, sets_len: c_uint, pk_out: *PublicKeyType, sig_out: *SignatureType) c_uint {
-    const pool = getMemoryPool(null) catch return c.BLST_BAD_ENCODING;
+    return doAggregateWithRandomness(null, sets, sets_len, pk_out, sig_out);
+}
+
+/// a zig application should pass the allocator to this function
+/// for Bun binding, allocator is null
+pub fn doAggregateWithRandomness(allocator: ?Allocator, sets: [*c]*const PkAndSerializedSigType, sets_len: c_uint, pk_out: *PublicKeyType, sig_out: *SignatureType) c_uint {
+    const pool = getMemoryPool(allocator) catch return c.BLST_BAD_ENCODING;
     const res = SigVariant.aggregateWithRandomnessC(sets, sets_len, pool, pk_out, sig_out, null);
     return res;
 }
 
-// TODO: implement equivalent api for zig application with allocator param
 export fn asyncAggregateWithRandomness(sets: [*c]*const PkAndSerializedSigType, sets_len: c_uint, pk_out: *PublicKeyType, sig_out: *SignatureType, callback: CallBackFn) c_uint {
-    const pool = getMemoryPool(null) catch return c.BLST_BAD_ENCODING;
+    return doAsyncAggregateWithRandomness(null, sets, sets_len, pk_out, sig_out, callback);
+}
+
+/// a zig application should pass the allocator to this function
+/// for Bun binding, allocator is null
+pub fn doAsyncAggregateWithRandomness(allocator: ?Allocator, sets: [*c]*const PkAndSerializedSigType, sets_len: c_uint, pk_out: *PublicKeyType, sig_out: *SignatureType, callback: CallBackFn) c_uint {
+    const pool = getMemoryPool(allocator) catch return c.BLST_BAD_ENCODING;
     return SigVariant.asyncAggregateWithRandomness(sets, sets_len, pool, pk_out, sig_out, callback);
 }
 

--- a/src/thread_pool.zig
+++ b/src/thread_pool.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
-var thread_pool: ?*std.Thread.Pool = null;
+threadlocal var thread_pool: ?*std.Thread.Pool = null;
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 
 /// a zig application may want to call this with a provided allocator

--- a/src/util.zig
+++ b/src/util.zig
@@ -88,6 +88,7 @@ pub fn default_blst_p2_affine() c.blst_p2_affine {
     };
 }
 
+// TODO: remove this if not consumed
 pub fn asU64Slice(bytes: []u8) ![]u64 {
     if ((@intFromPtr(bytes.ptr) % @alignOf(u64)) != 0) {
         return error.AlignmentError;

--- a/test/bun/src/aggregateWithRandomness.ts
+++ b/test/bun/src/aggregateWithRandomness.ts
@@ -18,9 +18,6 @@ export interface PkAndSig {
 // each 2 tems are 8 bytes, store the reference of each PkAndSerializedSig
 const pkAndSerializedSigsRefs = new Uint32Array(MAX_AGGREGATE_WITH_RANDOMNESS_PER_JOB * 2);
 
-const scratchPk = new Uint8Array(binding.sizeOfScratchPk(MAX_AGGREGATE_WITH_RANDOMNESS_PER_JOB));
-const scratchSig = new Uint8Array(binding.sizeOfScratchSig(MAX_AGGREGATE_WITH_RANDOMNESS_PER_JOB));
-
 /**
  * Aggregate multiple public keys and multiple serialized signatures into a single blinded public key and blinded signature.
  *
@@ -44,10 +41,6 @@ export function aggregateWithRandomness(sets: Array<PkAndSerializedSig>): PkAndS
 	const res = binding.aggregateWithRandomness(
 		refs,
 		sets.length,
-		scratchPk,
-		scratchPk.length,
-		scratchSig,
-		scratchSig.length,
 		pkOut.blst_point,
 		sigOut.blst_point
 	);
@@ -110,10 +103,6 @@ export function asyncAggregateWithRandomness(sets: Array<PkAndSerializedSig>): P
 		const res = binding.asyncAggregateWithRandomness(
 			pkAndSerializedSigsRefs,
 			sets.length,
-			scratchPk,
-			scratchPk.length,
-			scratchSig,
-			scratchSig.length,
 			pkOut.blst_point,
 			sigOut.blst_point,
 			jscallback

--- a/test/bun/src/aggregateWithRandomness.ts
+++ b/test/bun/src/aggregateWithRandomness.ts
@@ -38,12 +38,7 @@ export function aggregateWithRandomness(sets: Array<PkAndSerializedSig>): PkAndS
 	const pkOut = PublicKey.defaultPublicKey();
 	const sigOut = Signature.defaultSignature();
 
-	const res = binding.aggregateWithRandomness(
-		refs,
-		sets.length,
-		pkOut.blst_point,
-		sigOut.blst_point
-	);
+	const res = binding.aggregateWithRandomness(refs, sets.length, pkOut.blst_point, sigOut.blst_point);
 
 	if (res !== 0) {
 		throw new Error("Failed to aggregate with randomness res = " + res);

--- a/test/bun/src/binding.ts
+++ b/test/bun/src/binding.ts
@@ -122,12 +122,11 @@ const lib = dlopen(binaryPath, {
 		returns: "u32",
 	},
 	aggregateWithRandomness: {
-		args: ["ptr", "u32", "ptr", "u32", "ptr", "u32", "ptr", "ptr"],
+		args: ["ptr", "u32", "ptr", "ptr"],
 		returns: "u32",
 	},
 	asyncAggregateWithRandomness: {
-		args: ["ptr", "u32", "ptr", "u32", "ptr", "u32", "ptr", "ptr", "callback"],
-		// TODO: may return void instead
+		args: ["ptr", "u32", "ptr", "ptr", "callback"],
 		returns: "u32",
 	},
 	aggregateSerializedPublicKeys: {

--- a/test/bun/src/binding.ts
+++ b/test/bun/src/binding.ts
@@ -138,14 +138,6 @@ const lib = dlopen(binaryPath, {
 		args: ["ptr", "ptr", "u32", "u32", "bool"],
 		returns: "u32",
 	},
-	sizeOfScratchPk: {
-		args: ["u32"],
-		returns: "u32",
-	},
-	sizeOfScratchSig: {
-		args: ["u32"],
-		returns: "u32",
-	},
 	init: {
 		args: [],
 		returns: "u32",


### PR DESCRIPTION
**Motivation**
- it's not performant to always allocate pairing buffer and scratch buffers

**Description**
- implement MemoryPool which support multi thread
  - get buffers from it if available
  - return memory back to the pool when done
- as a result of this, at Bun side we don't need to allocate scratch buffers there which simplifies the binding