### PR TITLE
feat: implement pairing merge

### DIFF
--- a/src/pairing.zig
+++ b/src/pairing.zig
@@ -8,7 +8,7 @@ const c = @cImport({
     @cInclude("blst.h");
 });
 
-pub const PairingError = error{ BufferTooSmall, DstTooSmall };
+pub const PairingError = error{ BufferTooSmall, DstTooSmall, OutOfMemory, InvalidPairingBufferSize };
 
 const PTag = enum {
     p1,

--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -737,6 +737,7 @@ pub fn createSigVariant(
             waitAndWork(&wg);
 
             const valid = atomic_valid.load(.monotonic);
+            // do finalVerify() once in the main thread
             if (valid == c.BLST_SUCCESS and !acc.finalVerify(null)) {
                 return BLST_ERROR.VERIFY_FAIL;
             }
@@ -818,6 +819,7 @@ pub fn createSigVariant(
             waitAndWork(&wg);
 
             const valid = atomic_valid.load(.monotonic);
+            // do finalVerify() once in the main thread
             if (valid == c.BLST_SUCCESS and !acc.finalVerify(null)) {
                 return c.BLST_VERIFY_FAIL;
             }

--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -150,6 +150,10 @@ pub fn createSigVariant(
             }
         }
 
+        pub fn merge(self: *@This(), other: *const @This()) void {
+            self.p.merge(&other.p);
+        }
+
         pub fn finalVerify(self: *@This(), gtsig: ?*const c.blst_fp12) bool {
             return self.p.finalVerify(gtsig);
         }

--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -140,8 +140,18 @@ pub fn createSigVariant(
             self.p.commit();
         }
 
-        pub fn finalVerify(self: *@This(), ggtsig: ?*const c.blst_fp12) bool {
-            return self.p.finalVerify(ggtsig);
+        pub fn aggregated(gtsig: *c.blst_fp12, sig: *const sig_aff_type) void {
+            if (pk_comp_size == 48) {
+                // min_pk
+                P.aggregatedG1(gtsig, sig);
+            } else {
+                // min_sig
+                P.aggregatedG2(gtsig, sig);
+            }
+        }
+
+        pub fn finalVerify(self: *@This(), gtsig: ?*const c.blst_fp12) bool {
+            return self.p.finalVerify(gtsig);
         }
 
         // add more methods here if needed

--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -104,12 +104,20 @@ pub fn createSigVariant(
     sig_generator_fn: anytype,
     sig_to_affines_fn: anytype,
 ) type {
-    // TODO: implement MultiPoint
+    const MemoryPool = createMemoryPool(MAX_SIGNATURE_SETS, pk_scratch_size_of_fn, sig_scratch_size_of_fn, P.sizeOf);
+
     const Pairing = struct {
         p: P,
-        pub fn new(buffer: [*c]u8, buffer_len: usize, hoe: bool, dst: [*c]const u8, dst_len: usize) PairingError!@This() {
-            const p = try P.new(buffer, buffer_len, hoe, &dst[0], dst_len);
-            return .{ .p = p };
+        pool: *MemoryPool,
+        buffer: []u8,
+        pub fn new(pool: *MemoryPool, hoe: bool, dst: [*c]const u8, dst_len: usize) PairingError!@This() {
+            const buffer = try pool.getPairingBuffer();
+            const p = try P.new(&buffer[0], buffer.len, hoe, &dst[0], dst_len);
+            return .{ .p = p, .pool = pool, .buffer = buffer };
+        }
+
+        pub fn deinit(self: *@This()) !void {
+            try self.pool.returnPairingBuffer(self.buffer);
         }
 
         pub fn sizeOf() usize {
@@ -160,8 +168,6 @@ pub fn createSigVariant(
 
         // add more methods here if needed
     };
-
-    const MemoryPool = createMemoryPool(MAX_SIGNATURE_SETS, pk_scratch_size_of_fn, sig_scratch_size_of_fn, Pairing.sizeOf);
 
     // TODO: implement Clone, Copy, Equal
     // each function has 2 version: 1 for Zig and 1 for C-ABI
@@ -565,17 +571,14 @@ pub fn createSigVariant(
         // TODO: consider thread pool implementation
 
         /// same to non-std aggregate_verify in Rust, with extra `pairing_buffer` parameter
-        pub fn aggregateVerify(self: *const @This(), sig_groupcheck: bool, msgs: [][]const u8, dst: []const u8, pks: []const *PublicKey, pks_validate: bool, pairing_buffer: []u8) BLST_ERROR!void {
+        pub fn aggregateVerify(self: *const @This(), sig_groupcheck: bool, msgs: [][]const u8, dst: []const u8, pks: []const *PublicKey, pks_validate: bool, pool: *MemoryPool) BLST_ERROR!void {
             const n_elems = pks.len;
             if (n_elems == 0 or msgs.len != n_elems) {
                 return BLST_ERROR.VERIFY_FAIL;
             }
 
-            if (pairing_buffer.len < Pairing.sizeOf()) {
-                return BLST_ERROR.FAILED_PAIRING;
-            }
-
-            var pairing = Pairing.new(&pairing_buffer[0], pairing_buffer.len, hash_or_encode, &dst[0], dst.len) catch return BLST_ERROR.FAILED_PAIRING;
+            var pairing = Pairing.new(pool, hash_or_encode, &dst[0], dst.len) catch return BLST_ERROR.FAILED_PAIRING;
+            defer pairing.deinit() catch {};
 
             var msg = msgs[0];
             try pairing.aggregate(&pks[0].point, pks_validate, &self.point, sig_groupcheck, &msg[0], msg.len, null);
@@ -594,16 +597,13 @@ pub fn createSigVariant(
 
         /// C-ABI version of aggregateVerify()
         /// - extra msg_len parameter, all messages should have the same length
-        pub fn aggregateVerifyC(sig: *const sig_aff_type, sig_groupcheck: bool, msgs: [*c][*c]const u8, msgs_len: usize, msg_len: usize, dst: [*c]const u8, dst_len: usize, pks: [*c]const *pk_aff_type, pks_len: usize, pks_validate: bool, pairing_buffer: [*c]u8, pairing_buffer_len: usize) c_uint {
+        pub fn aggregateVerifyC(sig: *const sig_aff_type, sig_groupcheck: bool, msgs: [*c][*c]const u8, msgs_len: usize, msg_len: usize, dst: [*c]const u8, dst_len: usize, pks: [*c]const *pk_aff_type, pks_len: usize, pks_validate: bool, pool: *MemoryPool) c_uint {
             if (msgs_len == 0 or msgs_len != pks_len) {
                 return c.BLST_VERIFY_FAIL;
             }
 
-            if (pairing_buffer_len < Pairing.sizeOf()) {
-                return c.BLST_VERIFY_FAIL;
-            }
-
-            var pairing = Pairing.new(pairing_buffer, pairing_buffer_len, hash_or_encode, dst, dst_len) catch return c.BLST_VERIFY_FAIL;
+            var pairing = Pairing.new(pool, hash_or_encode, dst, dst_len) catch return c.BLST_VERIFY_FAIL;
+            defer pairing.deinit() catch {};
 
             var msg = msgs[0];
             pairing.aggregate(pks[0], pks_validate, sig, sig_groupcheck, msg, msg_len, null) catch return c.BLST_VERIFY_FAIL;
@@ -623,17 +623,17 @@ pub fn createSigVariant(
         }
 
         /// same to fast_aggregate_verify in Rust with extra `pairing_buffer` parameter
-        pub fn fastAggregateVerify(self: *const @This(), sig_groupcheck: bool, msg: []const u8, dst: []const u8, pks: []*const PublicKey, pairing_buffer: []u8) BLST_ERROR!void {
+        pub fn fastAggregateVerify(self: *const @This(), sig_groupcheck: bool, msg: []const u8, dst: []const u8, pks: []*const PublicKey, pool: *MemoryPool) BLST_ERROR!void {
             // this is unsafe code but we scanned through testTypeAlignment unit test
             const pk_aff_points: []*const pk_aff_type = @ptrCast(pks);
-            const res = fastAggregateVerifyC(&self.point, sig_groupcheck, &msg[0], msg.len, &dst[0], dst.len, &pk_aff_points[0], pk_aff_points.len, &pairing_buffer[0], pairing_buffer.len);
+            const res = fastAggregateVerifyC(&self.point, sig_groupcheck, &msg[0], msg.len, &dst[0], dst.len, &pk_aff_points[0], pk_aff_points.len, pool);
             const err_res = toBlstError(res);
             if (err_res) |err| {
                 return err;
             }
         }
 
-        pub fn fastAggregateVerifyC(sig: *const sig_aff_type, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, dst: [*c]const u8, dst_len: usize, pks: [*c]*const pk_aff_type, pks_len: usize, pairing_buffer: [*c]u8, pairing_buffer_len: usize) c_uint {
+        pub fn fastAggregateVerifyC(sig: *const sig_aff_type, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, dst: [*c]const u8, dst_len: usize, pks: [*c]*const pk_aff_type, pks_len: usize, pool: *MemoryPool) c_uint {
             var agg_pk = default_agg_pubkey_fn();
             const res = AggregatePublicKey.aggregatePublicKeys(&agg_pk, pks, pks_len, false);
             if (res != c.BLST_SUCCESS) {
@@ -644,22 +644,22 @@ pub fn createSigVariant(
 
             var msgs_arr = [_][*c]const u8{msg};
             var pks_arr = [_]*pk_aff_type{&pk};
-            return aggregateVerifyC(sig, sig_groupcheck, &msgs_arr, 1, msg_len, dst, dst_len, &pks_arr, 1, false, pairing_buffer, pairing_buffer_len);
+            return aggregateVerifyC(sig, sig_groupcheck, &msgs_arr, 1, msg_len, dst, dst_len, &pks_arr, 1, false, pool);
         }
 
         /// same to fast_aggregate_verify_pre_aggregated in Rust with extra `pairing_buffer` parameter
         /// TODO: make pk as *const PublicKey, then all other functions should make pks as []const *const PublicKey
-        pub fn fastAggregateVerifyPreAggregated(self: *const @This(), sig_groupcheck: bool, msg: []const u8, dst: []const u8, pk: *PublicKey, pairing_buffer: []u8) BLST_ERROR!void {
+        pub fn fastAggregateVerifyPreAggregated(self: *const @This(), sig_groupcheck: bool, msg: []const u8, dst: []const u8, pk: *PublicKey, pool: *MemoryPool) BLST_ERROR!void {
             var msgs = [_][]const u8{msg};
             var pks = [_]*PublicKey{pk};
-            try self.aggregateVerify(sig_groupcheck, msgs[0..], dst, pks[0..], false, pairing_buffer);
+            try self.aggregateVerify(sig_groupcheck, msgs[0..], dst, pks[0..], false, pool);
         }
 
         /// C-ABI version of fastAggregateVerifyPreAggregated()
-        pub fn fastAggregateVerifyPreAggregatedC(sig: *const sig_aff_type, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, dst: [*c]const u8, dst_len: usize, pk: *pk_aff_type, pairing_buffer: [*c]u8, pairing_buffer_len: usize) c_uint {
+        pub fn fastAggregateVerifyPreAggregatedC(sig: *const sig_aff_type, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, dst: [*c]const u8, dst_len: usize, pk: *pk_aff_type, pool: *MemoryPool) c_uint {
             var msgs = [_][*c]const u8{msg};
             var pks = [_]*pk_aff_type{pk};
-            return aggregateVerifyC(sig, sig_groupcheck, &msgs, 1, msg_len, dst, dst_len, &pks, pks.len, false, pairing_buffer, pairing_buffer_len);
+            return aggregateVerifyC(sig, sig_groupcheck, &msgs, 1, msg_len, dst, dst_len, &pks, pks.len, false, pool);
         }
 
         /// https://ethresear.ch/t/fast-verification-of-multiple-bls-signatures/5407
@@ -687,21 +687,14 @@ pub fn createSigVariant(
             for (0..n_workers) |_| {
                 spawnTaskWg(&wg, struct {
                     fn run(_msgs: [][]const u8, _dst: []const u8, _pks: []const *PublicKey, _pks_validate: bool, _sigs: []const *Signature, _sigs_groupcheck: bool, _rands: [][]const u8, _rand_bits: usize, _pool: *MemoryPool, _atomic_counter: *AtomicCounter, _atomic_valid: *AtomicError) void {
-                        const pairing_buffer = _pool.getPairingBuffer() catch {
+                        var pairing = Pairing.new(_pool, hash_or_encode, &_dst[0], _dst.len) catch {
                             // .release will publish the value to other threads
                             _atomic_valid.store(BLST_FAILED_PAIRING, AtomicOrder.release);
                             return;
                         };
-                        defer {
-                            _pool.returnPairingBuffer(pairing_buffer) catch {
-                                // .release will publish the value to other threads
-                                _atomic_valid.store(BLST_FAILED_PAIRING, AtomicOrder.release);
-                            };
-                        }
-                        var pairing = Pairing.new(&pairing_buffer[0], pairing_buffer.len, hash_or_encode, &_dst[0], _dst.len) catch {
+                        defer pairing.deinit() catch {
                             // .release will publish the value to other threads
                             _atomic_valid.store(BLST_FAILED_PAIRING, AtomicOrder.release);
-                            return;
                         };
 
                         // the most relaxed atomic ordering
@@ -760,21 +753,15 @@ pub fn createSigVariant(
             for (0..n_workers) |_| {
                 spawnTaskWg(&wg, struct {
                     fn run(_sets: [*c]*const SignatureSet, _sets_len: usize, _msg_len: usize, _dst: [*c]const u8, _dst_len: usize, _pks_validate: bool, _sigs_groupcheck: bool, _rands: [*c][*c]const u8, _rand_bits: usize, _pool: *MemoryPool, _atomic_counter: *AtomicCounter, _atomic_valid: *AtomicError) void {
-                        const pairing_buffer = _pool.getPairingBuffer() catch {
+                        var pairing = Pairing.new(_pool, hash_or_encode, _dst, _dst_len) catch {
                             // .release will publish the value to other threads
                             _atomic_valid.store(BLST_FAILED_PAIRING, AtomicOrder.release);
                             return;
                         };
-                        defer {
-                            _pool.returnPairingBuffer(pairing_buffer) catch {
-                                // .release will publish the value to other threads
-                                _atomic_valid.store(BLST_FAILED_PAIRING, AtomicOrder.release);
-                            };
-                        }
-                        var pairing = Pairing.new(&pairing_buffer[0], pairing_buffer.len, hash_or_encode, _dst, _dst_len) catch {
+
+                        defer pairing.deinit() catch {
                             // .release will publish the value to other threads
                             _atomic_valid.store(BLST_FAILED_PAIRING, AtomicOrder.release);
-                            return;
                         };
 
                         // the most relaxed atomic ordering
@@ -1669,11 +1656,15 @@ pub fn createSigVariant(
             const agg_sig = agg.toSignature();
 
             var allocator = std.testing.allocator;
-            const pairing_buffer = try allocator.alloc(u8, Pairing.sizeOf());
-            defer allocator.free(pairing_buffer);
+            const memory_pool = try allocator.create(MemoryPool);
+            try memory_pool.init(allocator);
+            defer {
+                memory_pool.deinit();
+                allocator.destroy(memory_pool);
+            }
 
             // positive test
-            try agg_sig.aggregateVerify(false, msgs[0..], dst, pks_ptr[0..], false, pairing_buffer);
+            try agg_sig.aggregateVerify(false, msgs[0..], dst, pks_ptr[0..], false, memory_pool);
 
             // only expect this to pass if all messages are the same length
             // const res = Signature.verifyMultipleAggregateSignaturesC(&sets[0], num_sigs, msg_lens[0], &dst[0], dst.len, false, false, &rands_c[0], rands_c.len, 64, &pairing_buffer[0], pairing_buffer.len);
@@ -1686,12 +1677,12 @@ pub fn createSigVariant(
                 for (pks_ptr[0..], 0..num_msgs) |pk, i| {
                     pks_refs[i] = &pk.point;
                 }
-                const res = Signature.aggregateVerifyC(&agg_sig.point, false, &msgs_refs[0], msgs_refs.len, same_msg_len, &dst[0], dst.len, &pks_refs[0], pks_refs.len, false, &pairing_buffer[0], pairing_buffer.len);
+                const res = Signature.aggregateVerifyC(&agg_sig.point, false, &msgs_refs[0], msgs_refs.len, same_msg_len, &dst[0], dst.len, &pks_refs[0], pks_refs.len, false, memory_pool);
                 try std.testing.expect(res == c.BLST_SUCCESS);
             }
 
             // Swap message/public key pairs to create bad signature
-            if (agg_sig.aggregateVerify(false, msgs[0..], dst, pks_ptr_rev[0..], false, pairing_buffer)) {
+            if (agg_sig.aggregateVerify(false, msgs[0..], dst, pks_ptr_rev[0..], false, memory_pool)) {
                 try std.testing.expect(false);
             } else |err| switch (err) {
                 BLST_ERROR.VERIFY_FAIL => {},
@@ -1702,8 +1693,12 @@ pub fn createSigVariant(
         pub fn testMultipleAggSigs(comptime is_diff_msg_len: bool) !void {
             var allocator = std.testing.allocator;
             // single pairing_buffer allocation that could be reused multiple times
-            const pairing_buffer = try allocator.alloc(u8, Pairing.sizeOf());
-            defer allocator.free(pairing_buffer);
+            const memory_pool = try allocator.create(MemoryPool);
+            try memory_pool.init(allocator);
+            defer {
+                memory_pool.deinit();
+                allocator.destroy(memory_pool);
+            }
 
             const dst = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
             const num_pks_per_sig = 10;
@@ -1768,11 +1763,11 @@ pub fn createSigVariant(
 
                 // Test current aggregate signature
                 sigs[i] = agg_i.toSignature();
-                try sigs[i].fastAggregateVerify(false, msgs[i], dst, pks_refs_i[0..], pairing_buffer);
+                try sigs[i].fastAggregateVerify(false, msgs[i], dst, pks_refs_i[0..], memory_pool);
 
                 // negative test
                 if (i != 0) {
-                    const verify_res = sigs[i - 1].fastAggregateVerify(false, msgs[i], dst, pks_refs_i[0..], pairing_buffer);
+                    const verify_res = sigs[i - 1].fastAggregateVerify(false, msgs[i], dst, pks_refs_i[0..], memory_pool);
                     if (verify_res) {
                         try std.testing.expect(false);
                     } else |err| {
@@ -1785,14 +1780,14 @@ pub fn createSigVariant(
                 pks[i] = pk_i.toPublicKey();
 
                 // Test current aggregate signature with aggregated pks
-                try sigs[i].fastAggregateVerifyPreAggregated(false, msgs[i], dst, &pks[i], pairing_buffer);
+                try sigs[i].fastAggregateVerifyPreAggregated(false, msgs[i], dst, &pks[i], memory_pool);
 
-                const res = Signature.fastAggregateVerifyPreAggregatedC(&sigs[i].point, false, &msgs[i][0], msgs[i].len, &dst[0], dst.len, &pks[i].point, &pairing_buffer[0], pairing_buffer.len);
+                const res = Signature.fastAggregateVerifyPreAggregatedC(&sigs[i].point, false, &msgs[i][0], msgs[i].len, &dst[0], dst.len, &pks[i].point, memory_pool);
                 try std.testing.expect(res == c.BLST_SUCCESS);
 
                 // negative test
                 if (i != 0) {
-                    const verify_res = sigs[i - 1].fastAggregateVerifyPreAggregated(false, msgs[i], dst, &pks[i], pairing_buffer);
+                    const verify_res = sigs[i - 1].fastAggregateVerifyPreAggregated(false, msgs[i], dst, &pks[i], memory_pool);
                     if (verify_res) {
                         try std.testing.expect(false);
                     } else |err| {
@@ -1837,12 +1832,8 @@ pub fn createSigVariant(
             }
 
             try initializeThreadPool(allocator);
-            const memory_pool = try allocator.create(MemoryPool);
-            try memory_pool.init(allocator);
             defer {
                 deinitializeThreadPool();
-                memory_pool.deinit();
-                allocator.destroy(memory_pool);
             }
 
             try Signature.verifyMultipleAggregateSignatures(msgs[0..], dst, pks_refs[0..], false, sigs_refs[0..], false, rands[0..], 64, memory_pool);

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -198,16 +198,22 @@ export fn verifySignature(sig: *const SignatureType, sig_groupcheck: bool, msg: 
     return Signature.verifySignature(sig, sig_groupcheck, msg, msg_len, &DST[0], DST.len, null, 0, pk, pk_validate);
 }
 
-export fn aggregateVerify(sig: *const SignatureType, sig_groupcheck: bool, msgs: [*c][*c]const u8, msgs_len: usize, msg_len: usize, pks: [*c]const *PublicKeyType, pks_len: usize, pks_validate: bool, pairing_buffer: [*c]u8, pairing_buffer_len: usize) c_uint {
-    return Signature.aggregateVerifyC(sig, sig_groupcheck, msgs, msgs_len, msg_len, &DST[0], DST.len, pks, pks_len, pks_validate, pairing_buffer, pairing_buffer_len);
+export fn aggregateVerify(sig: *const SignatureType, sig_groupcheck: bool, msgs: [*c][*c]const u8, msgs_len: usize, msg_len: usize, pks: [*c]const *PublicKeyType, pks_len: usize, pks_validate: bool) c_uint {
+    // TODO: same function for zig application with allocator
+    const pool = getMemoryPool(null) catch return c.BLST_BAD_ENCODING;
+    return Signature.aggregateVerifyC(sig, sig_groupcheck, msgs, msgs_len, msg_len, &DST[0], DST.len, pks, pks_len, pks_validate, pool);
 }
 
-export fn fastAggregateVerify(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pks: [*c]*const PublicKeyType, pks_len: usize, pairing_buffer: [*c]u8, pairing_buffer_len: usize) c_uint {
-    return Signature.fastAggregateVerifyC(sig, sig_groupcheck, msg, msg_len, &DST[0], DST.len, pks, pks_len, pairing_buffer, pairing_buffer_len);
+export fn fastAggregateVerify(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pks: [*c]*const PublicKeyType, pks_len: usize) c_uint {
+    // TODO: same function for zig application with allocator
+    const pool = getMemoryPool(null) catch return c.BLST_BAD_ENCODING;
+    return Signature.fastAggregateVerifyC(sig, sig_groupcheck, msg, msg_len, &DST[0], DST.len, pks, pks_len, pool);
 }
 
-export fn fastAggregateVerifyPreAggregated(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pk: *PublicKeyType, pairing_buffer: [*c]u8, pairing_buffer_len: usize) c_uint {
-    return Signature.fastAggregateVerifyPreAggregatedC(sig, sig_groupcheck, msg, msg_len, &DST[0], DST.len, pk, pairing_buffer, pairing_buffer_len);
+export fn fastAggregateVerifyPreAggregated(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pk: *PublicKeyType) c_uint {
+    // TODO: same function for zig application with allocator
+    const pool = getMemoryPool(null) catch return c.BLST_BAD_ENCODING;
+    return Signature.fastAggregateVerifyPreAggregatedC(sig, sig_groupcheck, msg, msg_len, &DST[0], DST.len, pk, pool);
 }
 
 const RAND_BYTES = 8;


### PR DESCRIPTION
**Motivation**
- merge pairing could improve performance, see https://github.com/ChainSafe/blst-z/pull/29/files#r2040605184
- implement missing pairing functions

**Description**
- in order to return pairing buffer back to memory pool, Pairing needs to hold MemoryPool and buffer, hence needs a big refactor. That was implemented in `Pairing.deinit()`, this reduced some boilerplate code