### PR TITLE
chore: use Zig slices in SigVariant

### DIFF
--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -131,13 +131,13 @@ pub fn createSigVariant(
             return P.sizeOf();
         }
 
-        pub fn aggregate(self: *@This(), pk: *const pk_aff_type, pk_validate: bool, sig: ?*const sig_aff_type, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, aug: ?[]u8) BLST_ERROR!void {
+        pub fn aggregate(self: *@This(), pk: *const pk_aff_type, pk_validate: bool, sig: ?*const sig_aff_type, sig_groupcheck: bool, msg: []const u8, aug: ?[]u8) BLST_ERROR!void {
             if (pk_comp_size == 48) {
                 // min_pk
-                return self.p.aggregateG1(pk, pk_validate, sig, sig_groupcheck, msg, msg_len, aug);
+                return self.p.aggregateG1(pk, pk_validate, sig, sig_groupcheck, &msg[0], msg.len, aug);
             } else {
                 // min_sig
-                return self.p.aggregateG2(pk, pk_validate, sig, sig_groupcheck, msg, msg_len, aug);
+                return self.p.aggregateG2(pk, pk_validate, sig, sig_groupcheck, &msg[0], msg.len, aug);
             }
         }
 
@@ -623,7 +623,7 @@ pub fn createSigVariant(
                             if (counter >= _msgs.len) {
                                 break;
                             }
-                            pairing.aggregate(&_pks[counter].point, _pks_validate, null, false, &_msgs[counter][0], _msgs[counter].len, null) catch {
+                            pairing.aggregate(&_pks[counter].point, _pks_validate, null, false, _msgs[counter], null) catch {
                                 // .release will publish the value to other threads
                                 _atomic_valid.store(c.BLST_VERIFY_FAIL, .release);
                                 return;
@@ -713,7 +713,7 @@ pub fn createSigVariant(
                             if (counter >= _msgs_len) {
                                 break;
                             }
-                            pairing.aggregate(_pks[counter], _pks_validate, null, false, _msgs[counter], _msg_len, null) catch {
+                            pairing.aggregate(_pks[counter], _pks_validate, null, false, _msgs[counter][0.._msg_len], null) catch {
                                 // .release will publish the value to other threads
                                 _atomic_valid.store(c.BLST_VERIFY_FAIL, AtomicOrder.release);
                                 return;

--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -1314,6 +1314,7 @@ pub fn createSigVariant(
             return sk;
         }
 
+        // cannot use slice for key gen functions because key_info could be null value
         pub fn secretKeyGen(out: *c.blst_scalar, ikm: [*c]const u8, ikm_len: usize, key_info: [*c]const u8, key_info_len: usize) c_uint {
             if (ikm_len < 32) {
                 return c.BLST_BAD_ENCODING;
@@ -1438,6 +1439,8 @@ pub fn createSigVariant(
             return sig_aff;
         }
 
+        // cannot use slice for aug because it could be null
+        // using C pointer for other params too for compatibility
         pub fn signC(out: *sig_aff_type, sk: *const c.blst_scalar, msg: [*c]const u8, msg_len: usize, dst: [*c]const u8, dst_len: usize, aug: [*c]const u8, aug_len: usize) void {
             var q = default_agg_sig_fn();
             hash_or_encode_to_fn(&q, msg, msg_len, dst, dst_len, aug, aug_len);

--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -216,15 +216,15 @@ pub fn createSigVariant(
         }
 
         pub fn keyValidate(key: []const u8) BLST_ERROR!void {
-            const res = publicKeyBytesValidate(&key[0], key.len);
+            const res = publicKeyBytesValidate(key);
             if (toBlstError(res)) |err| {
                 return err;
             }
         }
 
-        pub fn publicKeyBytesValidate(key: [*c]const u8, len: usize) c_uint {
+        pub fn publicKeyBytesValidate(key: []const u8) c_uint {
             var point = default().point;
-            const res = publicKeyFromBytes(&point, key, len);
+            const res = publicKeyFromBytes(&point, &key[0], key.len);
             if (res != c.BLST_SUCCESS) {
                 return res;
             }

--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -112,9 +112,9 @@ pub fn createSigVariant(
         pool: *MemoryPool,
         buffer: []u8,
         mutex: Mutex,
-        pub fn new(pool: *MemoryPool, hoe: bool, dst: [*c]const u8, dst_len: usize) PairingError!@This() {
+        pub fn new(pool: *MemoryPool, hoe: bool, dst: []const u8) PairingError!@This() {
             const buffer = try pool.getPairingBuffer();
-            const p = try P.new(&buffer[0], buffer.len, hoe, &dst[0], dst_len);
+            const p = try P.new(&buffer[0], buffer.len, hoe, &dst[0], dst.len);
             return .{
                 .p = p,
                 .pool = pool,
@@ -595,7 +595,7 @@ pub fn createSigVariant(
             const cpu_count = @max(1, std.Thread.getCpuCount() catch 1);
             const n_workers = @min(cpu_count, n_elems);
 
-            var acc = Pairing.new(pool, hash_or_encode, &dst[0], dst.len) catch {
+            var acc = Pairing.new(pool, hash_or_encode, dst) catch {
                 return BLST_ERROR.FAILED_PAIRING;
             };
 
@@ -604,7 +604,7 @@ pub fn createSigVariant(
             for (0..n_workers) |_| {
                 spawnTaskWg(&wg, struct {
                     fn run(_msgs: [][]const u8, _dst: []const u8, _pks: []const *PublicKey, _pks_validate: bool, _pool: *MemoryPool, _atomic_counter: *AtomicCounter, _atomic_valid: *AtomicError, _acc: *Pairing) void {
-                        var pairing = Pairing.new(_pool, hash_or_encode, &_dst[0], _dst.len) catch {
+                        var pairing = Pairing.new(_pool, hash_or_encode, _dst) catch {
                             // .release will publish the value to other threads
                             _atomic_valid.store(BLST_FAILED_PAIRING, AtomicOrder.release);
                             return;
@@ -685,7 +685,7 @@ pub fn createSigVariant(
             const cpu_count = @max(1, std.Thread.getCpuCount() catch 1);
             const n_workers = @min(cpu_count, msgs_len);
 
-            var acc = Pairing.new(pool, hash_or_encode, dst, dst_len) catch {
+            var acc = Pairing.new(pool, hash_or_encode, dst[0..dst_len]) catch {
                 return BLST_FAILED_PAIRING;
             };
 
@@ -694,7 +694,7 @@ pub fn createSigVariant(
             for (0..n_workers) |_| {
                 spawnTaskWg(&wg, struct {
                     fn run(_msgs: [*c][*c]const u8, _msgs_len: usize, _msg_len: usize, _dst: [*c]const u8, _dst_len: usize, _pks: [*c]const *pk_aff_type, _pks_validate: bool, _pool: *MemoryPool, _atomic_counter: *AtomicCounter, _atomic_valid: *AtomicError, _acc: *Pairing) void {
-                        var pairing = Pairing.new(_pool, hash_or_encode, _dst, _dst_len) catch {
+                        var pairing = Pairing.new(_pool, hash_or_encode, _dst[0.._dst_len]) catch {
                             // .release will publish the value to other threads
                             _atomic_valid.store(BLST_FAILED_PAIRING, AtomicOrder.release);
                             return;
@@ -817,7 +817,7 @@ pub fn createSigVariant(
             const n_workers = @min(cpu_count, n_elems);
             const Signature = @This();
 
-            var acc = Pairing.new(pool, hash_or_encode, &dst[0], dst.len) catch {
+            var acc = Pairing.new(pool, hash_or_encode, dst) catch {
                 return BLST_ERROR.FAILED_PAIRING;
             };
 
@@ -826,7 +826,7 @@ pub fn createSigVariant(
             for (0..n_workers) |_| {
                 spawnTaskWg(&wg, struct {
                     fn run(_msgs: [][]const u8, _dst: []const u8, _pks: []const *PublicKey, _pks_validate: bool, _sigs: []const *Signature, _sigs_groupcheck: bool, _rands: [][]const u8, _rand_bits: usize, _pool: *MemoryPool, _atomic_counter: *AtomicCounter, _atomic_valid: *AtomicError, _acc: *Pairing) void {
-                        var pairing = Pairing.new(_pool, hash_or_encode, &_dst[0], _dst.len) catch {
+                        var pairing = Pairing.new(_pool, hash_or_encode, _dst) catch {
                             // .release will publish the value to other threads
                             _atomic_valid.store(BLST_FAILED_PAIRING, AtomicOrder.release);
                             return;
@@ -895,7 +895,7 @@ pub fn createSigVariant(
 
             const cpu_count = @max(1, std.Thread.getCpuCount() catch 1);
             const n_workers = @min(cpu_count, sets_len);
-            var acc = Pairing.new(pool, hash_or_encode, dst, dst_len) catch {
+            var acc = Pairing.new(pool, hash_or_encode, dst[0..dst_len]) catch {
                 return BLST_FAILED_PAIRING;
             };
 
@@ -904,7 +904,7 @@ pub fn createSigVariant(
             for (0..n_workers) |_| {
                 spawnTaskWg(&wg, struct {
                     fn run(_sets: [*c]*const SignatureSet, _sets_len: usize, _msg_len: usize, _dst: [*c]const u8, _dst_len: usize, _pks_validate: bool, _sigs_groupcheck: bool, _rands: [*c][*c]const u8, _rand_bits: usize, _pool: *MemoryPool, _atomic_counter: *AtomicCounter, _atomic_valid: *AtomicError, _acc: *Pairing) void {
-                        var pairing = Pairing.new(_pool, hash_or_encode, _dst, _dst_len) catch {
+                        var pairing = Pairing.new(_pool, hash_or_encode, _dst[0.._dst_len]) catch {
                             // .release will publish the value to other threads
                             _atomic_valid.store(BLST_FAILED_PAIRING, AtomicOrder.release);
                             return;

--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -265,13 +265,13 @@ pub fn createSigVariant(
 
         pub fn uncompress(pk_comp: []const u8) BLST_ERROR!@This() {
             var pk = @This().default();
-            const res = uncompressPublicKey(&pk.point, &pk_comp[0], pk_comp.len);
+            const res = uncompressPublicKey(&pk.point, pk_comp);
             return toBlstError(res) orelse pk;
         }
 
-        pub fn uncompressPublicKey(out: *pk_aff_type, pk_comp: [*c]const u8, len: usize) c_uint {
-            if (len == pk_comp_size and (pk_comp.* & 0x80) != 0) {
-                return pk_uncomp_fn(out, pk_comp);
+        pub fn uncompressPublicKey(out: *pk_aff_type, pk_comp: []const u8) c_uint {
+            if (pk_comp.len == pk_comp_size and (pk_comp[0] & 0x80) != 0) {
+                return pk_uncomp_fn(out, &pk_comp[0]);
             }
 
             return c.BLST_BAD_ENCODING;

--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -1021,13 +1021,14 @@ pub fn createSigVariant(
             }
 
             const sig = @This().default();
-            const res = uncompressSignature(&sig.point, &sig_comp[0], sig_comp.len);
+            const res = uncompressSignature(&sig.point, sig_comp);
             return toBlstError(res) orelse sig;
         }
 
-        pub fn uncompressSignature(out: *sig_aff_type, sig_comp: [*c]const u8, len: usize) c_uint {
-            if (len == sig_comp_size and (sig_comp.* & 0x80) != 0) {
-                return sig_uncomp_fn(out, sig_comp);
+        pub fn uncompressSignature(out: *sig_aff_type, sig_comp: []const u8) c_uint {
+            const len = sig_comp.len;
+            if (len == sig_comp_size and (sig_comp[0] & 0x80) != 0) {
+                return sig_uncomp_fn(out, &sig_comp[0]);
             }
 
             return c.BLST_BAD_ENCODING;

--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -418,7 +418,8 @@ pub fn createSigVariant(
             return agg_pk;
         }
 
-        pub fn aggregateSerializedPublicKeys(out: *pk_type, pks: [*c][*c]const u8, pks_len: usize, pk_len: usize, pks_validate: bool) c_uint {
+        pub fn aggregateSerializedPublicKeys(out: *pk_type, pks: [][*c]const u8, pk_len: usize, pks_validate: bool) c_uint {
+            const pks_len = pks.len;
             if (pks_len <= 0) {
                 return c.BLST_AGGR_TYPE_MISMATCH;
             }

--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -1151,11 +1151,12 @@ pub fn createSigVariant(
             // this is unsafe code but we scanned through testTypeAlignment unit test
             const sigs_ptr: [*c]*const sig_aff_type = @ptrCast(&sigs[0]);
             var agg_sig = @This().default();
-            const res = aggregateSignatures(&agg_sig.point, sigs_ptr, sigs.len, sigs_groupcheck);
+            const res = aggregateSignatures(&agg_sig.point, sigs_ptr[0..sigs.len], sigs_groupcheck);
             return toBlstError(res) orelse agg_sig;
         }
 
-        pub fn aggregateSignatures(out: *sig_type, sigs: [*c]*const sig_aff_type, len: usize, sigs_groupcheck: bool) c_uint {
+        pub fn aggregateSignatures(out: *sig_type, sigs: []*const sig_aff_type, sigs_groupcheck: bool) c_uint {
+            const len = sigs.len;
             if (len == 0) {
                 return c.BLST_AGGR_TYPE_MISMATCH;
             }

--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -141,13 +141,13 @@ pub fn createSigVariant(
             }
         }
 
-        pub fn mulAndAggregate(self: *@This(), pk: *const pk_aff_type, pk_validate: bool, sig: *const sig_aff_type, sig_groupcheck: bool, scalar: [*c]const u8, nbits: usize, msg: [*c]const u8, msg_len: usize, aug: ?[]u8) BLST_ERROR!void {
+        pub fn mulAndAggregate(self: *@This(), pk: *const pk_aff_type, pk_validate: bool, sig: *const sig_aff_type, sig_groupcheck: bool, scalar: [*c]const u8, nbits: usize, msg: []const u8, aug: ?[]u8) BLST_ERROR!void {
             if (pk_comp_size == 48) {
                 // min_pk
-                return self.p.mulAndAggregateG1(pk, pk_validate, sig, sig_groupcheck, scalar, nbits, msg, msg_len, aug);
+                return self.p.mulAndAggregateG1(pk, pk_validate, sig, sig_groupcheck, scalar, nbits, &msg[0], msg.len, aug);
             } else {
                 // min_sig
-                return self.p.mulAndAggregateG2(pk, pk_validate, sig, sig_groupcheck, scalar, nbits, msg, msg_len, aug);
+                return self.p.mulAndAggregateG2(pk, pk_validate, sig, sig_groupcheck, scalar, nbits, &msg[0], msg.len, aug);
             }
         }
 
@@ -845,7 +845,7 @@ pub fn createSigVariant(
                             if (counter >= _msgs.len) {
                                 break;
                             }
-                            pairing.mulAndAggregate(&_pks[counter].point, _pks_validate, &_sigs[counter].point, _sigs_groupcheck, &_rands[counter][0], _rand_bits, &_msgs[counter][0], _msgs[counter].len, null) catch {
+                            pairing.mulAndAggregate(&_pks[counter].point, _pks_validate, &_sigs[counter].point, _sigs_groupcheck, &_rands[counter][0], _rand_bits, _msgs[counter], null) catch {
                                 // .release will publish the value to other threads
                                 _atomic_valid.store(c.BLST_VERIFY_FAIL, .release);
                                 return;
@@ -925,7 +925,7 @@ pub fn createSigVariant(
                                 break;
                             }
                             const set = _sets[counter];
-                            pairing.mulAndAggregate(set.pk, _pks_validate, set.sig, _sigs_groupcheck, _rands[counter], _rand_bits, set.msg, _msg_len, null) catch {
+                            pairing.mulAndAggregate(set.pk, _pks_validate, set.sig, _sigs_groupcheck, _rands[counter], _rand_bits, set.msg[0.._msg_len], null) catch {
                                 // .release will publish the value to other threads
                                 _atomic_valid.store(c.BLST_VERIFY_FAIL, .release);
                                 return;

--- a/src/sig_variant.zig
+++ b/src/sig_variant.zig
@@ -407,6 +407,7 @@ pub fn createSigVariant(
         // cannot deduplicate this function with the below 3 functions because pks may contain different sizes
         pub fn aggregateSerialized(pks: [][]const u8, pks_validate: bool) BLST_ERROR!@This() {
             // TODO - threading
+            // rust binding is also not implementing multi-thread anyway
             if (pks.len == 0) {
                 return BLST_ERROR.AGGR_TYPE_MISMATCH;
             }

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -156,7 +156,7 @@ export fn aggregateToPublicKey(out: *PublicKeyType, agg_pk: *const AggregatePubl
 
 export fn aggregatePublicKeys(out: *PublicKeyType, pks: [*c]*const PublicKeyType, len: usize, pks_validate: bool) c_uint {
     var aggregate_pk = defaultAggregatePublicKey();
-    const res = AggregatePublicKey.aggregatePublicKeys(&aggregate_pk, pks, len, pks_validate);
+    const res = AggregatePublicKey.aggregatePublicKeys(&aggregate_pk, pks[0..len], pks_validate);
     aggregateToPublicKey(out, &aggregate_pk);
     return res;
 }
@@ -213,7 +213,7 @@ export fn fastAggregateVerify(sig: *const SignatureType, sig_groupcheck: bool, m
 
 pub fn doFastAggregateVerify(allocator: ?Allocator, sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pks: [*c]*const PublicKeyType, pks_len: usize) c_uint {
     const pool = getMemoryPool(allocator) catch return util.MEMORY_POOL_ERROR;
-    return Signature.fastAggregateVerifyC(sig, sig_groupcheck, msg, msg_len, &DST[0], DST.len, pks, pks_len, pool);
+    return Signature.fastAggregateVerifyC(sig, sig_groupcheck, msg, msg_len, &DST[0], DST.len, pks[0..pks_len], pool);
 }
 
 export fn fastAggregateVerifyPreAggregated(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pk: *PublicKeyType) c_uint {

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -226,8 +226,12 @@ export fn aggregateVerify(sig: *const SignatureType, sig_groupcheck: bool, msgs:
 }
 
 pub fn doAggregateVerify(allocator: ?Allocator, sig: *const SignatureType, sig_groupcheck: bool, msgs: [*c][*c]const u8, msgs_len: usize, msg_len: usize, pks: [*c]const *PublicKeyType, pks_len: usize, pks_validate: bool) c_uint {
+    if (msgs_len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
+
     const pool = getMemoryPool(allocator) catch return util.MEMORY_POOL_ERROR;
-    return Signature.aggregateVerifyC(sig, sig_groupcheck, msgs, msgs_len, msg_len, &DST[0], DST.len, pks, pks_len, pks_validate, pool);
+    return Signature.aggregateVerifyC(sig, sig_groupcheck, msgs[0..msgs_len], msg_len, DST, pks[0..pks_len], pks_validate, pool);
 }
 
 export fn fastAggregateVerify(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pks: [*c]*const PublicKeyType, pks_len: usize) c_uint {
@@ -239,7 +243,7 @@ pub fn doFastAggregateVerify(allocator: ?Allocator, sig: *const SignatureType, s
         return c.BLST_BAD_ENCODING;
     }
     const pool = getMemoryPool(allocator) catch return util.MEMORY_POOL_ERROR;
-    return Signature.fastAggregateVerifyC(sig, sig_groupcheck, msg, msg_len, &DST[0], DST.len, pks[0..pks_len], pool);
+    return Signature.fastAggregateVerifyC(sig, sig_groupcheck, msg, msg_len, DST, pks[0..pks_len], pool);
 }
 
 export fn fastAggregateVerifyPreAggregated(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pk: *PublicKeyType) c_uint {
@@ -248,7 +252,7 @@ export fn fastAggregateVerifyPreAggregated(sig: *const SignatureType, sig_groupc
 
 pub fn doFastAggregateVerifyPreAggregated(allocator: ?Allocator, sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pk: *PublicKeyType) c_uint {
     const pool = getMemoryPool(allocator) catch return util.MEMORY_POOL_ERROR;
-    return Signature.fastAggregateVerifyPreAggregatedC(sig, sig_groupcheck, msg, msg_len, &DST[0], DST.len, pk, pool);
+    return Signature.fastAggregateVerifyPreAggregatedC(sig, sig_groupcheck, msg, msg_len, DST, pk, pool);
 }
 
 const RAND_BYTES = 8;

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -106,7 +106,7 @@ export fn validatePublicKey(pk: *const PublicKeyType) c_uint {
 }
 
 export fn publicKeyBytesValidate(key: [*c]const u8, len: usize) c_uint {
-    return PublicKey.publicKeyBytesValidate(key, len);
+    return PublicKey.publicKeyBytesValidate(key[0..len]);
 }
 
 export fn publicKeyFromAggregate(out: *PublicKeyType, agg_pk: *const AggregatePublicKeyType) void {

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -106,6 +106,9 @@ export fn validatePublicKey(pk: *const PublicKeyType) c_uint {
 }
 
 export fn publicKeyBytesValidate(key: [*c]const u8, len: usize) c_uint {
+    if (len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
     return PublicKey.publicKeyBytesValidate(key[0..len]);
 }
 
@@ -122,14 +125,23 @@ export fn serializePublicKey(out: *u8, point: *const PublicKeyType) void {
 }
 
 export fn uncompressPublicKey(out: *PublicKeyType, pk_comp: [*c]const u8, len: usize) c_uint {
+    if (len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
     return PublicKey.uncompressPublicKey(out, pk_comp[0..len]);
 }
 
 export fn deserializePublicKey(out: *PublicKeyType, pk_in: [*c]const u8, len: usize) c_uint {
+    if (len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
     return PublicKey.deserializePublicKey(out, pk_in[0..len]);
 }
 
 export fn publicKeyFromBytes(point: *PublicKeyType, pk_in: [*c]const u8, len: usize) c_uint {
+    if (len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
     return PublicKey.publicKeyFromBytes(point, pk_in[0..len]);
 }
 
@@ -155,6 +167,9 @@ export fn aggregateToPublicKey(out: *PublicKeyType, agg_pk: *const AggregatePubl
 }
 
 export fn aggregatePublicKeys(out: *PublicKeyType, pks: [*c]*const PublicKeyType, len: usize, pks_validate: bool) c_uint {
+    if (len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
     var aggregate_pk = defaultAggregatePublicKey();
     const res = AggregatePublicKey.aggregatePublicKeys(&aggregate_pk, pks[0..len], pks_validate);
     aggregateToPublicKey(out, &aggregate_pk);
@@ -162,6 +177,9 @@ export fn aggregatePublicKeys(out: *PublicKeyType, pks: [*c]*const PublicKeyType
 }
 
 export fn aggregateSerializedPublicKeys(out: *PublicKeyType, pks: [*c][*c]const u8, pks_len: usize, pk_len: usize, pks_validate: bool) c_uint {
+    if (pks_len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
     var aggregate_pk = defaultAggregatePublicKey();
     const res = AggregatePublicKey.aggregateSerializedPublicKeys(&aggregate_pk, pks[0..pks_len], pk_len, pks_validate);
     aggregateToPublicKey(out, &aggregate_pk);
@@ -190,7 +208,10 @@ export fn validateSignature(sig: *const SignatureType, sig_infcheck: bool) c_uin
 }
 
 export fn sigValidate(out: *SignatureType, sig: [*c]const u8, sig_len: usize, sig_infcheck: bool) c_uint {
-    return Signature.sigValidateC(out, sig, sig_len, sig_infcheck);
+    if (sig_len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
+    return Signature.sigValidateC(out, sig[0..sig_len], sig_infcheck);
 }
 
 export fn verifySignature(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pk: *const PublicKeyType, pk_validate: bool) c_uint {
@@ -212,6 +233,9 @@ export fn fastAggregateVerify(sig: *const SignatureType, sig_groupcheck: bool, m
 }
 
 pub fn doFastAggregateVerify(allocator: ?Allocator, sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pks: [*c]*const PublicKeyType, pks_len: usize) c_uint {
+    if (pks_len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
     const pool = getMemoryPool(allocator) catch return util.MEMORY_POOL_ERROR;
     return Signature.fastAggregateVerifyC(sig, sig_groupcheck, msg, msg_len, &DST[0], DST.len, pks[0..pks_len], pool);
 }
@@ -278,11 +302,17 @@ export fn uncompressSignature(out: *SignatureType, sig_comp: [*c]const u8, len: 
 }
 
 export fn deserializeSignature(out: *SignatureType, sig_in: [*c]const u8, len: usize) c_uint {
-    return Signature.deserializeSignature(out, sig_in, len);
+    if (len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
+    return Signature.deserializeSignature(out, sig_in[0..len]);
 }
 
 export fn signatureFromBytes(out: *SignatureType, sig_in: [*c]const u8, len: usize) c_uint {
-    return Signature.signatureFromBytes(out, sig_in, len);
+    if (len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
+    return Signature.signatureFromBytes(out, sig_in[0..len]);
 }
 
 export fn signatureToBytes(out: *u8, point: *SignatureType) void {
@@ -322,8 +352,11 @@ export fn aggregateSignatures(out: *SignatureType, sigs: [*c]*const SignatureTyp
 }
 
 export fn aggregateSerializedSignatures(out: *SignatureType, sigs: [*c][*c]const u8, sigs_len: usize, sig_len: usize, sigs_groupcheck: bool) c_uint {
+    if (sigs_len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
     var aggregate_sig = defaultAggregateSignature();
-    const res = AggregateSignature.aggregateSerializedC(&aggregate_sig, sigs, sigs_len, sig_len, sigs_groupcheck);
+    const res = AggregateSignature.aggregateSerializedC(&aggregate_sig, sigs[0..sigs_len], sig_len, sigs_groupcheck);
     aggregateToSignature(out, &aggregate_sig);
     return res;
 }
@@ -440,6 +473,9 @@ export fn aggregateWithRandomness(sets: [*c]*const PkAndSerializedSigType, sets_
 /// a zig application should pass the allocator to this function
 /// for Bun binding, allocator is null
 pub fn doAggregateWithRandomness(allocator: ?Allocator, sets: [*c]*const PkAndSerializedSigType, sets_len: c_uint, pk_out: *PublicKeyType, sig_out: *SignatureType) c_uint {
+    if (sets_len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
     const pool = getMemoryPool(allocator) catch return util.MEMORY_POOL_ERROR;
     const res = SigVariant.aggregateWithRandomnessC(sets[0..sets_len], pool, pk_out, sig_out, null);
     return res;
@@ -452,6 +488,9 @@ export fn asyncAggregateWithRandomness(sets: [*c]*const PkAndSerializedSigType, 
 /// a zig application should pass the allocator to this function
 /// for Bun binding, allocator is null
 pub fn doAsyncAggregateWithRandomness(allocator: ?Allocator, sets: [*c]*const PkAndSerializedSigType, sets_len: c_uint, pk_out: *PublicKeyType, sig_out: *SignatureType, callback: CallBackFn) c_uint {
+    if (sets_len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
     const pool = getMemoryPool(allocator) catch return util.MEMORY_POOL_ERROR;
     return SigVariant.asyncAggregateWithRandomness(sets[0..sets_len], pool, pk_out, sig_out, callback);
 }

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -122,7 +122,7 @@ export fn serializePublicKey(out: *u8, point: *const PublicKeyType) void {
 }
 
 export fn uncompressPublicKey(out: *PublicKeyType, pk_comp: [*c]const u8, len: usize) c_uint {
-    return PublicKey.uncompressPublicKey(out, pk_comp, len);
+    return PublicKey.uncompressPublicKey(out, pk_comp[0..len]);
 }
 
 export fn deserializePublicKey(out: *PublicKeyType, pk_in: [*c]const u8, len: usize) c_uint {

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -215,8 +215,10 @@ export fn sigValidate(out: *SignatureType, sig: [*c]const u8, sig_len: usize, si
 }
 
 export fn verifySignature(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pk: *const PublicKeyType, pk_validate: bool) c_uint {
-    // aug_ptr is null, aug_len is 0
-    return Signature.verifySignature(sig, sig_groupcheck, msg, msg_len, &DST[0], DST.len, null, 0, pk, pk_validate);
+    if (msg_len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
+    return Signature.verifySignature(sig, sig_groupcheck, msg[0..msg_len], DST, null, pk, pk_validate);
 }
 
 export fn aggregateVerify(sig: *const SignatureType, sig_groupcheck: bool, msgs: [*c][*c]const u8, msgs_len: usize, msg_len: usize, pks: [*c]const *PublicKeyType, pks_len: usize, pks_validate: bool) c_uint {

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -126,11 +126,11 @@ export fn uncompressPublicKey(out: *PublicKeyType, pk_comp: [*c]const u8, len: u
 }
 
 export fn deserializePublicKey(out: *PublicKeyType, pk_in: [*c]const u8, len: usize) c_uint {
-    return PublicKey.deserializePublicKey(out, pk_in, len);
+    return PublicKey.deserializePublicKey(out, pk_in[0..len]);
 }
 
 export fn publicKeyFromBytes(point: *PublicKeyType, pk_in: [*c]const u8, len: usize) c_uint {
-    return PublicKey.publicKeyFromBytes(point, pk_in, len);
+    return PublicKey.publicKeyFromBytes(point, pk_in[0..len]);
 }
 
 export fn toPublicKeyBytes(out: *u8, point: *PublicKeyType) void {

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -252,8 +252,12 @@ export fn fastAggregateVerifyPreAggregated(sig: *const SignatureType, sig_groupc
 }
 
 pub fn doFastAggregateVerifyPreAggregated(allocator: ?Allocator, sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pk: *PublicKeyType) c_uint {
+    if (msg_len == 0) {
+        return c.BLST_BAD_ENCODING;
+    }
+
     const pool = getMemoryPool(allocator) catch return util.MEMORY_POOL_ERROR;
-    return Signature.fastAggregateVerifyPreAggregatedC(sig, sig_groupcheck, msg, msg_len, DST, pk, pool);
+    return Signature.fastAggregateVerifyPreAggregatedC(sig, sig_groupcheck, msg[0..msg_len], DST, pk, pool);
 }
 
 const RAND_BYTES = 8;

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -359,7 +359,7 @@ export fn aggregateToSignature(out: *SignatureType, agg_sig: *const AggregateSig
 
 export fn aggregateSignatures(out: *SignatureType, sigs: [*c]*const SignatureType, len: usize, sigs_groupcheck: bool) c_uint {
     var aggregate_sig = defaultAggregateSignature();
-    const res = AggregateSignature.aggregateSignatures(&aggregate_sig, sigs, len, sigs_groupcheck);
+    const res = AggregateSignature.aggregateSignatures(&aggregate_sig, sigs[0..len], sigs_groupcheck);
     aggregateToSignature(out, &aggregate_sig);
     return res;
 }

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -163,7 +163,7 @@ export fn aggregatePublicKeys(out: *PublicKeyType, pks: [*c]*const PublicKeyType
 
 export fn aggregateSerializedPublicKeys(out: *PublicKeyType, pks: [*c][*c]const u8, pks_len: usize, pk_len: usize, pks_validate: bool) c_uint {
     var aggregate_pk = defaultAggregatePublicKey();
-    const res = AggregatePublicKey.aggregateSerializedPublicKeys(&aggregate_pk, pks, pks_len, pk_len, pks_validate);
+    const res = AggregatePublicKey.aggregateSerializedPublicKeys(&aggregate_pk, pks[0..pks_len], pk_len, pks_validate);
     aggregateToPublicKey(out, &aggregate_pk);
     return res;
 }

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -310,7 +310,8 @@ export fn serializeSignature(out: *u8, point: *const SignatureType) void {
 }
 
 export fn uncompressSignature(out: *SignatureType, sig_comp: [*c]const u8, len: usize) c_uint {
-    return Signature.uncompressSignature(out, sig_comp, len);
+    // validate len inside uncompressSignature
+    return Signature.uncompressSignature(out, sig_comp[0..len]);
 }
 
 export fn deserializeSignature(out: *SignatureType, sig_in: [*c]const u8, len: usize) c_uint {

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -239,11 +239,12 @@ export fn fastAggregateVerify(sig: *const SignatureType, sig_groupcheck: bool, m
 }
 
 pub fn doFastAggregateVerify(allocator: ?Allocator, sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pks: [*c]*const PublicKeyType, pks_len: usize) c_uint {
-    if (pks_len == 0) {
+    if (pks_len == 0 or msg_len == 0) {
         return c.BLST_BAD_ENCODING;
     }
+
     const pool = getMemoryPool(allocator) catch return util.MEMORY_POOL_ERROR;
-    return Signature.fastAggregateVerifyC(sig, sig_groupcheck, msg, msg_len, DST, pks[0..pks_len], pool);
+    return Signature.fastAggregateVerifyC(sig, sig_groupcheck, msg[0..msg_len], DST, pks[0..pks_len], pool);
 }
 
 export fn fastAggregateVerifyPreAggregated(sig: *const SignatureType, sig_groupcheck: bool, msg: [*c]const u8, msg_len: usize, pk: *PublicKeyType) c_uint {

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -441,7 +441,7 @@ export fn aggregateWithRandomness(sets: [*c]*const PkAndSerializedSigType, sets_
 /// for Bun binding, allocator is null
 pub fn doAggregateWithRandomness(allocator: ?Allocator, sets: [*c]*const PkAndSerializedSigType, sets_len: c_uint, pk_out: *PublicKeyType, sig_out: *SignatureType) c_uint {
     const pool = getMemoryPool(allocator) catch return util.MEMORY_POOL_ERROR;
-    const res = SigVariant.aggregateWithRandomnessC(sets, sets_len, pool, pk_out, sig_out, null);
+    const res = SigVariant.aggregateWithRandomnessC(sets[0..sets_len], pool, pk_out, sig_out, null);
     return res;
 }
 
@@ -453,7 +453,7 @@ export fn asyncAggregateWithRandomness(sets: [*c]*const PkAndSerializedSigType, 
 /// for Bun binding, allocator is null
 pub fn doAsyncAggregateWithRandomness(allocator: ?Allocator, sets: [*c]*const PkAndSerializedSigType, sets_len: c_uint, pk_out: *PublicKeyType, sig_out: *SignatureType, callback: CallBackFn) c_uint {
     const pool = getMemoryPool(allocator) catch return util.MEMORY_POOL_ERROR;
-    return SigVariant.asyncAggregateWithRandomness(sets, sets_len, pool, pk_out, sig_out, callback);
+    return SigVariant.asyncAggregateWithRandomness(sets[0..sets_len], pool, pk_out, sig_out, callback);
 }
 
 /// a Bun application should call this before using any of the exported functions

--- a/src/sig_variant_min_pk.zig
+++ b/src/sig_variant_min_pk.zig
@@ -288,12 +288,13 @@ pub fn doVerifyMultipleAggregateSignatures(allocator: ?Allocator, sets: [*c]*con
     }
     rand_refs_initialized = true;
 
-    if (sets_len > MAX_SIGNATURE_SETS) {
+    if (sets_len == 0 or sets_len > MAX_SIGNATURE_SETS) {
         return c.BLST_BAD_ENCODING;
     }
+
     randBytes(rands[0..(sets_len * 8)]);
     const pool = getMemoryPool(allocator) catch return util.MEMORY_POOL_ERROR;
-    return Signature.verifyMultipleAggregateSignaturesC(sets, sets_len, msg_len, &DST[0], DST.len, pks_validate, sigs_groupcheck, &rand_refs[0], sets_len, RAND_BITS, pool);
+    return Signature.verifyMultipleAggregateSignaturesC(sets[0..sets_len], msg_len, DST, pks_validate, sigs_groupcheck, rand_refs[0..sets_len], RAND_BITS, pool);
 }
 
 export fn signatureFromAggregate(out: *SignatureType, agg_sig: *const AggregateSignatureType) void {

--- a/test/bun/src/publicKey.ts
+++ b/test/bun/src/publicKey.ts
@@ -32,6 +32,10 @@ export class PublicKey {
 	 * If `pk_validate` is `true`, the public key will be infinity and group checked.
 	 */
 	static fromBytes(bytes: Uint8Array, pkValidate?: boolean | undefined | null): PublicKey {
+    if (bytes.length !== PUBLIC_KEY_LENGTH_COMPRESSED && bytes.length !== PUBLIC_KEY_LENGTH_UNCOMPRESSED) {
+      throw new Error("Invalid encoding");
+    }
+
 		const buffer = new Uint8Array(PUBLIC_KEY_LENGTH_UNCOMPRESSED);
 		let res = binding.deserializePublicKey(buffer, bytes, bytes.length);
 		if (res !== BLST_SUCCESS) {

--- a/test/bun/src/publicKey.ts
+++ b/test/bun/src/publicKey.ts
@@ -32,9 +32,9 @@ export class PublicKey {
 	 * If `pk_validate` is `true`, the public key will be infinity and group checked.
 	 */
 	static fromBytes(bytes: Uint8Array, pkValidate?: boolean | undefined | null): PublicKey {
-    if (bytes.length !== PUBLIC_KEY_LENGTH_COMPRESSED && bytes.length !== PUBLIC_KEY_LENGTH_UNCOMPRESSED) {
-      throw new Error("Invalid encoding");
-    }
+		if (bytes.length !== PUBLIC_KEY_LENGTH_COMPRESSED && bytes.length !== PUBLIC_KEY_LENGTH_UNCOMPRESSED) {
+			throw new Error("Invalid encoding");
+		}
 
 		const buffer = new Uint8Array(PUBLIC_KEY_LENGTH_UNCOMPRESSED);
 		let res = binding.deserializePublicKey(buffer, bytes, bytes.length);

--- a/test/bun/src/secretKey.ts
+++ b/test/bun/src/secretKey.ts
@@ -98,9 +98,9 @@ export class SecretKey {
 
 	/** Return the signature */
 	sign(msg: Uint8Array): Signature {
-    if (msg.length === 0) {
-      throw new Error("Message cannot be empty");
-    }
+		if (msg.length === 0) {
+			throw new Error("Message cannot be empty");
+		}
 
 		return Signature.sign(msg, this.blst_point);
 	}

--- a/test/bun/src/secretKey.ts
+++ b/test/bun/src/secretKey.ts
@@ -98,6 +98,10 @@ export class SecretKey {
 
 	/** Return the signature */
 	sign(msg: Uint8Array): Signature {
+    if (msg.length === 0) {
+      throw new Error("Message cannot be empty");
+    }
+
 		return Signature.sign(msg, this.blst_point);
 	}
 }

--- a/test/bun/src/signature.ts
+++ b/test/bun/src/signature.ts
@@ -21,9 +21,9 @@ export class Signature {
 	 * Called from SecretKey so that we keep the constructor private.
 	 */
 	static sign(msg: Uint8Array, sk: Uint8Array): Signature {
-    if (msg.length === 0) {
-      throw new Error("Message cannot be empty");
-    }
+		if (msg.length === 0) {
+			throw new Error("Message cannot be empty");
+		}
 
 		const buffer = new Uint8Array(SIGNATURE_LENGTH_UNCOMPRESSED);
 		binding.sign(buffer, sk, msg, msg.length);

--- a/test/bun/src/signature.ts
+++ b/test/bun/src/signature.ts
@@ -21,6 +21,10 @@ export class Signature {
 	 * Called from SecretKey so that we keep the constructor private.
 	 */
 	static sign(msg: Uint8Array, sk: Uint8Array): Signature {
+    if (msg.length === 0) {
+      throw new Error("Message cannot be empty");
+    }
+
 		const buffer = new Uint8Array(SIGNATURE_LENGTH_UNCOMPRESSED);
 		binding.sign(buffer, sk, msg, msg.length);
 		return new Signature(buffer);

--- a/test/bun/src/verify.ts
+++ b/test/bun/src/verify.ts
@@ -93,6 +93,10 @@ export function fastAggregateVerify(
 	sig: Signature,
 	sigsGroupcheck?: boolean | undefined | null
 ): boolean {
+  if (msg.length === 0) {
+    throw new Error("Message cannot be empty");
+  }
+
 	const pksReferences = writePublicKeysReference(pks);
 	const res = binding.fastAggregateVerify(
 		sig.blst_point,

--- a/test/bun/src/verify.ts
+++ b/test/bun/src/verify.ts
@@ -17,9 +17,9 @@ export function verify(
 	pkValidate?: boolean | undefined | null,
 	sigGroupcheck?: boolean | undefined | null
 ): boolean {
-  if (msg.length === 0) {
-    throw new Error("Message cannot be empty");
-  }
+	if (msg.length === 0) {
+		throw new Error("Message cannot be empty");
+	}
 
 	const res = binding.verifySignature(
 		sig.blst_point,
@@ -93,9 +93,9 @@ export function fastAggregateVerify(
 	sig: Signature,
 	sigsGroupcheck?: boolean | undefined | null
 ): boolean {
-  if (msg.length === 0) {
-    throw new Error("Message cannot be empty");
-  }
+	if (msg.length === 0) {
+		throw new Error("Message cannot be empty");
+	}
 
 	const pksReferences = writePublicKeysReference(pks);
 	const res = binding.fastAggregateVerify(

--- a/test/bun/src/verify.ts
+++ b/test/bun/src/verify.ts
@@ -17,6 +17,10 @@ export function verify(
 	pkValidate?: boolean | undefined | null,
 	sigGroupcheck?: boolean | undefined | null
 ): boolean {
+  if (msg.length === 0) {
+    throw new Error("Message cannot be empty");
+  }
+
 	const res = binding.verifySignature(
 		sig.blst_point,
 		sigGroupcheck ?? false,


### PR DESCRIPTION
**Motivation**
- up until now, in SigVariant all C functions have to accept a `"len"` parameter along with a C pointer `[*c]something` which is  redundant since it can work with slice (Zig specific) instead: `something[0..len]`

**Description**
- C-ABI files to work with C pointers and len params
- internal implementation (SigVariant) to work with slice
- when calling C functions, for example, Pairing, convert back to C pointers and len
- check len > 0 before doing that
- same check at bun side