### PR TITLE
feat: fetch blst as a zig dependency in build.zig.zon

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,19 +33,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          submodules: recursive # Ensures submodules are cloned
-          fetch-depth: 0        # Fetches the entire history for all branches
 
       - name: Print OS ${{ matrix.settings.os }}
         run: uname -a
       - name: Print Architecture ${{ matrix.settings.arch }}
         run: uname -m
-
-      - name: Verify Submodules
-        run: |
-          git submodule update --init --recursive
-          ls -la blst
 
       - name: Install Zig
         uses: mlugg/setup-zig@v1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "blst"]
-	path = blst
-	url = https://github.com/supranational/blst.git

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -65,6 +65,11 @@
         //    // actually used.
         //    .lazy = false,
         //},
+        // zig fetch  https://github.com/supranational/blst/archive/refs/tags/v0.3.13.tar.gz
+        .blst = .{
+            .url = "https://github.com/supranational/blst/archive/refs/tags/v0.3.13.tar.gz",
+            .hash = "N-V-__8AAHB4OgByNs3JJNXs9f2gxmbJBYqM7HBRHfmwZa-e",
+        },
     },
 
     // Specifies the set of files and directories that are included in this package.


### PR DESCRIPTION
**Motivation**
- `blst` is currently manually fetched using `git submodule` command which makes it hard for consumer projects
- relying on a "git submodule update" is also not great for a new developer to set up his dev environment

**Description**
- `zig fetch https://github.com/supranational/blst/archive/refs/tags/v0.3.13.tar.gz`
- manually declare "blst" dependency in `build.zig.zon`
- then use that dependency inside `build.zig`