### PR TITLE
fix: alignment for pairing bufs

### DIFF
--- a/src/Pairing.zig
+++ b/src/Pairing.zig
@@ -3,6 +3,10 @@ ctx: *c.blst_pairing,
 
 const Self = @This();
 
+/// Required alignment for the pairing buffer. The opaque C struct contains
+/// `uptr_t` (64-bit) fields that require 8-byte alignment.
+pub const buf_align = 8;
+
 /// Initializes a pairing context with the provided `buffer` and other parameters.
 /// This `Pairing` instance owns the given memory.
 ///
@@ -11,7 +15,7 @@ const Self = @This();
 /// - it does not have allocator in its api
 /// - can use stack allocation at consumer side
 /// - can reuse memory if it makes sense at consumer side
-pub fn init(buffer: *[Self.sizeOf()]u8, hash_or_encode: bool, dst: []const u8) Self {
+pub fn init(buffer: *align(buf_align) [Self.sizeOf()]u8, hash_or_encode: bool, dst: []const u8) Self {
     const obj = Self{ .ctx = @ptrCast(buffer) };
     c.blst_pairing_init(obj.ctx, hash_or_encode, @ptrCast(dst.ptr), dst.len);
 
@@ -129,12 +133,10 @@ pub fn asFp12(self: *Self) *c.blst_fp12 {
 }
 
 test "init Pairing" {
-    const allocator = std.testing.allocator;
-    const buffer = try allocator.alloc(u8, @This().sizeOf());
-    defer allocator.free(buffer);
+    var buffer: [sizeOf()]u8 align(buf_align) = undefined;
 
     const dst = "destination";
-    _ = @This().init(@ptrCast(buffer), true, dst);
+    _ = @This().init(&buffer, true, dst);
 }
 
 test "sizeOf Pairing" {

--- a/src/Signature.zig
+++ b/src/Signature.zig
@@ -61,7 +61,7 @@ pub fn verify(
 pub fn aggregateVerify(
     self: *const Self,
     sig_groupcheck: bool,
-    buffer: *[Pairing.sizeOf()]u8,
+    buffer: *align(Pairing.buf_align) [Pairing.sizeOf()]u8,
     msgs: []const [32]u8,
     dst: []const u8,
     pks: []const PublicKey,
@@ -105,7 +105,7 @@ pub fn aggregateVerify(
 pub fn fastAggregateVerify(
     self: *const Self,
     sig_groupcheck: bool,
-    buffer: *[Pairing.sizeOf()]u8,
+    buffer: *align(Pairing.buf_align) [Pairing.sizeOf()]u8,
     msg: *const [32]u8,
     dst: []const u8,
     pks: []const PublicKey,
@@ -130,7 +130,7 @@ pub fn fastAggregateVerify(
 pub fn fastAggregateVerifyPreAggregated(
     self: *const Self,
     sig_groupcheck: bool,
-    buffer: *[Pairing.sizeOf()]u8,
+    buffer: *align(Pairing.buf_align) [Pairing.sizeOf()]u8,
     msg: *const [32]u8,
     dst: []const u8,
     pk: *const PublicKey,
@@ -264,7 +264,7 @@ test aggregateVerify {
 
     const num_sigs = 10;
 
-    var buffer: [3192]u8 = undefined;
+    var buffer: [Pairing.sizeOf()]u8 align(Pairing.buf_align) = undefined;
 
     var msgs: [num_sigs][32]u8 = undefined;
     var sks: [num_sigs]SecretKey = undefined;

--- a/src/fast_verify.zig
+++ b/src/fast_verify.zig
@@ -10,7 +10,7 @@ const RAND_BITS = 8 * RAND_BYTES;
 ///
 /// Returns true if verification succeeds, false if verification fails, `BlstError` on error.
 pub fn verifyMultipleAggregateSignatures(
-    pairing_buf: *[Pairing.sizeOf()]u8,
+    pairing_buf: *align(Pairing.buf_align) [Pairing.sizeOf()]u8,
     n_elems: usize,
     msgs: []const [32]u8,
     dst: []const u8,

--- a/test/spec/test_case.zig
+++ b/test/spec/test_case.zig
@@ -85,7 +85,7 @@ pub fn aggregate_verify(gpa: Allocator, path: std.fs.Dir) !void {
 
         var pk_buf: [blst.PublicKey.COMPRESS_SIZE]u8 = undefined;
         var sig_buf: [blst.Signature.COMPRESS_SIZE]u8 = undefined;
-        var pairing_buf: [blst.Pairing.sizeOf()]u8 = undefined;
+        var pairing_buf: [blst.Pairing.sizeOf()]u8 align(blst.Pairing.buf_align) = undefined;
 
         for (aggregate_verify_test_data.input.pubkeys, 0..) |pk_hex_bytes, i| {
             const pk_bytes = try std.fmt.hexToBytes(
@@ -155,7 +155,7 @@ pub fn fast_aggregate_verify(gpa: Allocator, path: std.fs.Dir) !void {
         var msg_bytes: [32]u8 = undefined;
         var pk_buf: [blst.PublicKey.COMPRESS_SIZE]u8 = undefined;
         var sig_buf: [blst.Signature.COMPRESS_SIZE]u8 = undefined;
-        var pairing_buf: [blst.Pairing.sizeOf()]u8 = undefined;
+        var pairing_buf: [blst.Pairing.sizeOf()]u8 align(blst.Pairing.buf_align) = undefined;
 
         for (fast_aggregate_verify_test_data.input.pubkeys, 0..) |pk_hex_bytes, i| {
             const pk_bytes = try std.fmt.hexToBytes(
@@ -381,7 +381,7 @@ pub fn eth_fast_aggregate_verify(gpa: Allocator, path: std.fs.Dir) !void {
         var msg_bytes: [32]u8 = undefined;
         var pk_buf: [blst.PublicKey.COMPRESS_SIZE]u8 = undefined;
         var sig_buf: [blst.Signature.COMPRESS_SIZE]u8 = undefined;
-        var pairing_buf: [blst.Pairing.sizeOf()]u8 = undefined;
+        var pairing_buf: [blst.Pairing.sizeOf()]u8 align(blst.Pairing.buf_align) = undefined;
 
         for (eth_fast_aggregate_verify_test_data.input.pubkeys, 0..) |pk_hex_bytes, i| {
             const pk_bytes = try std.fmt.hexToBytes(


### PR DESCRIPTION
alignment of `[N]u8` is `@alignOf(u8)` (which is 1) - we have to manually align it to the alignment of the underlying C pointer used by blst.