### PR TITLE
add benchmarks

### DIFF
--- a/bench/verify_multiple.zig
+++ b/bench/verify_multiple.zig
@@ -1,0 +1,80 @@
+const std = @import("std");
+const zbench = @import("zbench");
+const blst = @import("blst");
+
+const Pairing = blst.Pairing;
+const SecretKey = blst.SecretKey;
+const PublicKey = blst.PublicKey;
+const Signature = blst.Signature;
+const DST = blst.DST;
+
+const MAX_COUNT = 256;
+
+var pks: [MAX_COUNT]PublicKey = undefined;
+var pk_ptrs: [MAX_COUNT]*PublicKey = undefined;
+var sigs: [MAX_COUNT]Signature = undefined;
+var sig_ptrs: [MAX_COUNT]*Signature = undefined;
+var msgs: [MAX_COUNT][32]u8 = undefined;
+var rands: [MAX_COUNT][32]u8 = undefined;
+
+fn generateTestSets() void {
+    for (0..MAX_COUNT) |i| {
+        // Deterministic IKM per index
+        var ikm: [32]u8 = [_]u8{0} ** 32;
+        std.mem.writeInt(u64, ikm[0..8], @intCast(i + 1), .little);
+
+        const sk = SecretKey.keyGen(&ikm, null) catch unreachable;
+        pks[i] = sk.toPublicKey();
+        pk_ptrs[i] = &pks[i];
+
+        // Deterministic message per index
+        msgs[i] = [_]u8{0} ** 32;
+        std.mem.writeInt(u64, msgs[i][0..8], @intCast(i), .little);
+
+        sigs[i] = sk.sign(&msgs[i], DST, null);
+        sig_ptrs[i] = &sigs[i];
+
+        // Deterministic random scalar per index
+        rands[i] = [_]u8{0} ** 32;
+        rands[i][0] = @intCast((i % 255) + 1); // must be non-zero
+    }
+}
+
+fn VerifyMultipleBench(comptime count: usize) type {
+    return struct {
+        pub fn run(_: @This(), allocator: std.mem.Allocator) void {
+            _ = allocator;
+            var pairing_buf: [Pairing.sizeOf()]u8 align(Pairing.buf_align) = undefined;
+            const result = blst.verifyMultipleAggregateSignatures(
+                &pairing_buf,
+                count,
+                msgs[0..count],
+                DST,
+                pk_ptrs[0..count],
+                false,
+                sig_ptrs[0..count],
+                false,
+                rands[0..count],
+            ) catch false;
+            std.mem.doNotOptimizeAway(&result);
+        }
+    };
+}
+
+pub fn main() !void {
+    const allocator = std.heap.page_allocator;
+    const stdout = std.io.getStdOut().writer();
+
+    generateTestSets();
+
+    var bench = zbench.Benchmark.init(allocator, .{});
+    defer bench.deinit();
+
+    try bench.addParam("1 sets", &VerifyMultipleBench(1){}, .{});
+    try bench.addParam("8 sets", &VerifyMultipleBench(8){}, .{});
+    try bench.addParam("32 sets", &VerifyMultipleBench(32){}, .{});
+    try bench.addParam("128 sets", &VerifyMultipleBench(128){}, .{});
+    try bench.addParam("256 sets", &VerifyMultipleBench(256){}, .{});
+
+    try bench.run(stdout);
+}

--- a/build.zig
+++ b/build.zig
@@ -7,10 +7,12 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const portable = b.option(bool, "portable", "turn on portable mode") orelse true;
+
     const blst_c = b.dependency("blst", .{
         .target = target,
         .optimize = optimize,
-        .portable = b.option(bool, "portable", "turn on portable mode") orelse true,
+        .portable = portable,
     });
 
     const lib_blst_c = blst_c.artifact("blst");
@@ -97,4 +99,44 @@ pub fn build(b: *std.Build) !void {
     if (b.args) |args| run_spec_tests.addArgs(args);
     const tls_run_spec_tests = b.step("run_spec_tests", "Run the spec tests");
     tls_run_spec_tests.dependOn(&run_spec_tests.step);
+
+    // benchmarks
+
+    const bench_optimize = .ReleaseFast;
+
+    const bench_blst_c = b.dependency("blst", .{
+        .target = target,
+        .optimize = bench_optimize,
+        .portable = portable,
+    });
+
+    const bench_blst_mod = b.addModule("blst_bench", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = bench_optimize,
+    });
+    bench_blst_mod.linkLibrary(bench_blst_c.artifact("blst"));
+    bench_blst_mod.addIncludePath(bench_blst_c.path("include"));
+
+    const dep_zbench = b.dependency("zbench", .{
+        .optimize = bench_optimize,
+        .target = target,
+    });
+
+    const bench_verify_multiple = b.addExecutable(.{
+        .name = "bench_verify_multiple",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("bench/verify_multiple.zig"),
+            .target = target,
+            .optimize = bench_optimize,
+        }),
+    });
+    bench_verify_multiple.root_module.addImport("blst", bench_blst_mod);
+    bench_verify_multiple.root_module.addImport("zbench", dep_zbench.module("zbench"));
+
+    b.installArtifact(bench_verify_multiple);
+
+    const run_bench_verify_multiple = b.addRunArtifact(bench_verify_multiple);
+    const bench_step = b.step("bench", "Run benchmarks");
+    bench_step.dependOn(&run_bench_verify_multiple.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,6 +12,10 @@
             .url = "git+https://github.com/chainsafe/zig-yaml#e0e5962579e990a66c21424416c7ac092b20b772",
             .hash = "zig_yaml-0.1.0-C1161m2NAgDhth5OvjG1o1UNKcdo-XNfO82m10J1g4Cl",
         },
+        .zbench = .{
+            .url = "git+https://github.com/hendriknielaender/zBench#d8c7dd485306b88b757d52005614ebcb0a336942",
+            .hash = "zbench-0.10.0-YTdc714iAQDO4lTHMnIljYHPZ5v_sNTsw75vAmO1pyT-",
+        },
     },
     .paths = .{
         "build.zig",


### PR DESCRIPTION
add very simple benchmarks based on #60 

run with `zig build bench`:

```console
$ zig build bench
benchmark              runs     total time     time/run (avg ± σ)     (min ... max)                p75        p99        p995
-----------------------------------------------------------------------------------------------------------------------------
1 sets                 2194     1.944s         886.117us ± 85.968us   (853.75us ... 2.957ms)       893.417us  997.583us  1.052ms
8 sets                 1700     1.872s         1.101ms ± 168.443us    (977.25us ... 4.014ms)       1.125ms    1.494ms    1.92ms
32 sets                827      1.95s          2.358ms ± 296.992us    (2.143ms ... 5.147ms)        2.444ms    3.328ms    3.433ms
128 sets               265      2.151s         8.119ms ± 4.43ms       (6.798ms ... 65.68ms)        7.952ms    32.904ms   35.793ms
256 sets               142      1.967s         13.856ms ± 913.826us   (13.04ms ... 17.935ms)       14.259ms   17.845ms   17.935ms
```
