### PR TITLE
refactor: use slice of ptrs in aggregateVerify for reusability in multi-threaded version

### DIFF
--- a/src/Signature.zig
+++ b/src/Signature.zig
@@ -64,7 +64,7 @@ pub fn aggregateVerify(
     buffer: *align(Pairing.buf_align) [Pairing.sizeOf()]u8,
     msgs: []const [32]u8,
     dst: []const u8,
-    pks: []const PublicKey,
+    pks: []const *const PublicKey,
     pks_validate: bool,
 ) BlstError!bool {
     const n_elems = pks.len;
@@ -73,7 +73,7 @@ pub fn aggregateVerify(
     }
     var pairing = Pairing.init(buffer, true, dst);
     try pairing.aggregate(
-        &pks[0],
+        pks[0],
         pks_validate,
         self,
         sig_groupcheck,
@@ -83,7 +83,7 @@ pub fn aggregateVerify(
 
     for (1..n_elems) |i| {
         try pairing.aggregate(
-            &pks[i],
+            pks[i],
             pks_validate,
             null,
             sig_groupcheck,
@@ -119,7 +119,7 @@ pub fn fastAggregateVerify(
         buffer,
         @ptrCast(msg),
         dst,
-        &[_]PublicKey{pk},
+        &[_]*const PublicKey{&pk},
         false,
     );
 }
@@ -135,13 +135,12 @@ pub fn fastAggregateVerifyPreAggregated(
     dst: []const u8,
     pk: *const PublicKey,
 ) BlstError!bool {
-    const pks: [*]const PublicKey = @ptrCast(pk);
     return try self.aggregateVerify(
         sig_groupcheck,
         buffer,
         @ptrCast(msg),
         dst,
-        pks[0..1],
+        &[_]*const PublicKey{pk},
         false,
     );
 }
@@ -269,6 +268,7 @@ test aggregateVerify {
     var msgs: [num_sigs][32]u8 = undefined;
     var sks: [num_sigs]SecretKey = undefined;
     var pks: [num_sigs]PublicKey = undefined;
+    var pk_ptrs: [num_sigs]*PublicKey = undefined;
     var sigs: [num_sigs]@This() = undefined;
 
     for (0..num_sigs) |i| {
@@ -278,11 +278,12 @@ test aggregateVerify {
 
         sks[i] = sk;
         pks[i] = pk;
+        pk_ptrs[i] = &pks[i];
         sigs[i] = sig;
     }
 
     const agg_sig = try AggregateSignature.aggregate(&sigs, false);
     const sig = @This().fromAggregate(&agg_sig);
 
-    try std.testing.expect(try sig.aggregateVerify(false, &buffer, &msgs, dst, &pks, false));
+    try std.testing.expect(try sig.aggregateVerify(false, &buffer, &msgs, dst, &pk_ptrs, false));
 }

--- a/src/ThreadPool.zig
+++ b/src/ThreadPool.zig
@@ -40,9 +40,12 @@ pairing_bufs: [MAX_WORKERS]PairingBuf = [_]PairingBuf{.{}} ** MAX_WORKERS,
 partial_p1: [MAX_WORKERS]c.blst_p1 = undefined,
 partial_p2: [MAX_WORKERS]c.blst_p2 = undefined,
 has_work: [MAX_WORKERS]bool = [_]bool{false} ** MAX_WORKERS,
+/// Mutex for dispatching multi-threaded verification work.
+dispatch_mutex: std.Thread.Mutex = .{},
 
 var instance: ?*ThreadPool = null;
-var mutex: std.Thread.Mutex = .{};
+/// Mutex responsible for access to the global `ThreadPool` singleton.
+var pool_mutex: std.Thread.Mutex = .{};
 
 /// Pairing size is = ~3.1KB * `MAX_WORKERS` = ~50KB
 /// We allocate 4 pages (4 * 16KB) for this at startup.
@@ -50,8 +53,8 @@ const allocator = std.heap.page_allocator;
 
 /// Returns the global thread pool singleton, creating it if necessary.
 pub fn get() *ThreadPool {
-    mutex.lock();
-    defer mutex.unlock();
+    pool_mutex.lock();
+    defer pool_mutex.unlock();
 
     if (instance) |pool| return pool;
     const pool = allocator.create(ThreadPool) catch
@@ -86,9 +89,9 @@ pub fn deinit(pool: *ThreadPool) void {
     for (pool.threads[0 .. n_workers - 1]) |t| {
         t.join();
     }
-    mutex.lock();
+    pool_mutex.lock();
     if (instance == pool) instance = null;
-    mutex.unlock();
+    pool_mutex.unlock();
     allocator.destroy(pool);
 }
 
@@ -209,6 +212,9 @@ pub fn verifyMultipleAggregateSignatures(
         rands.len != n_elems)
         return BlstError.VerifyFail;
 
+    pool.dispatch_mutex.lock();
+    defer pool.dispatch_mutex.unlock();
+
     // Single-threaded fallback for small inputs or single worker
     if (n_elems <= 2 or pool.n_workers <= 1) {
         const fast_verify = @import("fast_verify.zig");
@@ -307,6 +313,9 @@ pub fn aggregateVerify(
 ) BlstError!bool {
     const n_elems = pks.len;
     if (n_elems == 0 or msgs.len != n_elems) return BlstError.VerifyFail;
+
+    pool.dispatch_mutex.lock();
+    defer pool.dispatch_mutex.unlock();
 
     // Single-threaded fallback
     if (n_elems <= 2 or pool.n_workers <= 1) {

--- a/src/ThreadPool.zig
+++ b/src/ThreadPool.zig
@@ -298,16 +298,16 @@ pub fn aggregateVerify(
     dst: []const u8,
     pks: []const *PublicKey,
     pks_validate: bool,
-) bool {
+) BlstError!bool {
     const n_elems = pks.len;
-    if (n_elems == 0 or msgs.len != n_elems) return false;
+    if (n_elems == 0 or msgs.len != n_elems) return BlstError.VerifyFail;
 
     // Single-threaded fallback
     if (n_elems <= 2 or pool.n_workers <= 1) {
         var pairing = Pairing.init(&pool.pairing_bufs[0].data, true, dst);
-        pairing.aggregate(pks[0], pks_validate, sig, sig_groupcheck, &msgs[0], null) catch return false;
+        try pairing.aggregate(pks[0], pks_validate, sig, sig_groupcheck, &msgs[0], null);
         for (1..n_elems) |i| {
-            pairing.aggregate(pks[i], pks_validate, null, false, &msgs[i], null) catch return false;
+            try pairing.aggregate(pks[i], pks_validate, null, false, &msgs[i], null);
         }
         pairing.commit();
         var gtsig = c.blst_fp12{};
@@ -459,14 +459,12 @@ test "aggregateVerify multi-threaded" {
     const agg_sig = AggregateSignature.aggregate(&sigs, false) catch return error.AggregationFailed;
     const final_sig = agg_sig.toSignature();
 
-    const result = pool.aggregateVerify(
+    try std.testing.expect(try pool.aggregateVerify(
         &final_sig,
         false,
         &msgs,
         blst.DST,
         &pk_ptrs,
         true,
-    );
-
-    try std.testing.expect(result);
+    ));
 }

--- a/src/ThreadPool.zig
+++ b/src/ThreadPool.zig
@@ -128,8 +128,8 @@ fn dispatch(pool: *ThreadPool, item: WorkItem, n_active: usize) void {
 }
 
 const VerifyMultiJob = struct {
-    pks: []const *PublicKey,
-    sigs: []const *Signature,
+    pks: []const *const PublicKey,
+    sigs: []const *const Signature,
     msgs: []const [32]u8,
     rands: []const [32]u8,
     dst: []const u8,
@@ -182,9 +182,9 @@ pub fn verifyMultipleAggregateSignatures(
     n_elems: usize,
     msgs: []const [32]u8,
     dst: []const u8,
-    pks: []const *PublicKey,
+    pks: []const *const PublicKey,
     pks_validate: bool,
-    sigs: []const *Signature,
+    sigs: []const *const Signature,
     sigs_groupcheck: bool,
     rands: []const [32]u8,
 ) BlstError!bool {
@@ -237,7 +237,7 @@ pub fn verifyMultipleAggregateSignatures(
 }
 
 const AggVerifyJob = struct {
-    pks: []const *PublicKey,
+    pks: []const *const PublicKey,
     msgs: []const [32]u8,
     dst: []const u8,
     pks_validate: bool,
@@ -291,7 +291,7 @@ pub fn aggregateVerify(
     sig_groupcheck: bool,
     msgs: []const [32]u8,
     dst: []const u8,
-    pks: []const *PublicKey,
+    pks: []const *const PublicKey,
     pks_validate: bool,
 ) BlstError!bool {
     const n_elems = pks.len;
@@ -302,15 +302,7 @@ pub fn aggregateVerify(
 
     // Single-threaded fallback
     if (n_elems <= 2 or pool.n_workers <= 1) {
-        var pairing = Pairing.init(&pool.pairing_bufs[0].data, true, dst);
-        try pairing.aggregate(pks[0], pks_validate, sig, sig_groupcheck, &msgs[0], null);
-        for (1..n_elems) |i| {
-            try pairing.aggregate(pks[i], pks_validate, null, false, &msgs[i], null);
-        }
-        pairing.commit();
-        var gtsig = c.blst_fp12{};
-        Pairing.aggregated(&gtsig, sig);
-        return pairing.finalVerify(&gtsig);
+        return sig.aggregateVerify(sig_groupcheck, &pool.pairing_bufs[0].data, msgs, dst, pks, pks_validate);
     }
 
     const n_active = @min(pool.n_workers, n_elems);

--- a/src/ThreadPool.zig
+++ b/src/ThreadPool.zig
@@ -1,0 +1,295 @@
+//! Thread pool for parallel BLS operations.
+//!
+//! Provides multi-threaded versions of aggregation and verification functions
+//! using a persistent pool of worker threads to avoid thread creation overhead.
+const ThreadPool = @This();
+
+const std = @import("std");
+const c = @cImport({
+    @cInclude("blst.h");
+});
+const Pairing = @import("Pairing.zig");
+const blst = @import("root.zig");
+const PublicKey = blst.PublicKey;
+const Signature = blst.Signature;
+const BlstError = @import("error.zig").BlstError;
+const SecretKey = @import("SecretKey.zig");
+
+pub const MAX_WORKERS: usize = 16;
+
+/// Number of random bits used for verification.
+const RAND_BITS = 64;
+
+/// Minimum number of elements before using multi-threaded aggregation.
+const AGGREGATION_MT_THRESHOLD = 64;
+
+const PairingBuf = struct {
+    data: [Pairing.sizeOf()]u8 align(Pairing.buf_align) = undefined,
+};
+
+n_workers: usize,
+threads: [MAX_WORKERS - 1]std.Thread = undefined,
+work_ready: [MAX_WORKERS]std.Thread.ResetEvent = [_]std.Thread.ResetEvent{.{}} ** MAX_WORKERS,
+work_done: [MAX_WORKERS]std.Thread.ResetEvent = [_]std.Thread.ResetEvent{.{}} ** MAX_WORKERS,
+work_items: [MAX_WORKERS]?*VerifyMultiJob = [_]?*VerifyMultiJob{null} ** MAX_WORKERS,
+shutdown: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+pairing_bufs: [MAX_WORKERS]PairingBuf = [_]PairingBuf{.{}} ** MAX_WORKERS,
+partial_p1: [MAX_WORKERS]c.blst_p1 = undefined,
+partial_p2: [MAX_WORKERS]c.blst_p2 = undefined,
+has_work: [MAX_WORKERS]bool = [_]bool{false} ** MAX_WORKERS,
+
+var instance: ?*ThreadPool = null;
+
+/// Pairing size is = ~3.1KB * `MAX_WORKERS` = ~50KB
+/// We allocate 4 pages (4 * 16KB) for this at startup.
+const allocator = std.heap.page_allocator;
+
+/// Returns the global thread pool singleton, creating it if necessary.
+pub fn get() *ThreadPool {
+    if (instance) |pool| return pool;
+    const pool = allocator.create(ThreadPool) catch
+        @panic("ThreadPool: failed to allocate");
+    pool.* = .{
+        .n_workers = blk: {
+            const cpu_count = std.Thread.getCpuCount() catch 1;
+            // Use 3/4 of available cores: aggregation saturates early so doesn't
+            // need all cores, while leaving headroom for the host application
+            // (e.g. Node.js event loop, libuv I/O threads).
+            break :blk @min(@max(cpu_count * 3 / 4, 2), MAX_WORKERS);
+        },
+    };
+    for (1..pool.n_workers) |i| {
+        pool.threads[i - 1] = std.Thread.spawn(.{}, workerLoop, .{ pool, i }) catch
+            @panic("ThreadPool: failed to spawn worker");
+    }
+    instance = pool;
+    return pool;
+}
+
+/// Shuts down the thread pool and frees resources.
+/// The pool pointer is invalid after this call.
+pub fn deinit(pool: *ThreadPool) void {
+    pool.shutdown.store(true, .release);
+    const n_workers = pool.n_workers;
+    for (1..n_workers) |i| {
+        pool.work_ready[i].set();
+    }
+    for (pool.threads[0 .. n_workers - 1]) |t| {
+        t.join();
+    }
+    if (instance == pool) instance = null;
+    allocator.destroy(pool);
+}
+
+fn workerLoop(pool: *ThreadPool, worker_index: usize) void {
+    while (true) {
+        pool.work_ready[worker_index].wait();
+        pool.work_ready[worker_index].reset();
+
+        if (pool.shutdown.load(.acquire)) return;
+
+        const job = pool.work_items[worker_index] orelse {
+            pool.work_done[worker_index].set();
+            continue;
+        };
+
+        execVerifyMulti(pool, job, worker_index);
+
+        pool.work_items[worker_index] = null;
+        pool.work_done[worker_index].set();
+    }
+}
+
+fn dispatch(pool: *ThreadPool) void {
+    // Signal background workers before main thread starts
+    for (1..pool.n_workers) |i| {
+        pool.work_ready[i].set();
+    }
+
+    // Main thread executes as worker 0
+    if (pool.work_items[0]) |job| {
+        execVerifyMulti(pool, job, 0);
+        pool.work_items[0] = null;
+    }
+
+    // Wait for all background workers
+    for (1..pool.n_workers) |i| {
+        pool.work_done[i].wait();
+        pool.work_done[i].reset();
+    }
+}
+
+const VerifyMultiJob = struct {
+    pks: []const *PublicKey,
+    sigs: []const *Signature,
+    msgs: []const [32]u8,
+    rands: []const [32]u8,
+    dst: []const u8,
+    pks_validate: bool,
+    sigs_groupcheck: bool,
+    counter: std.atomic.Value(usize),
+    err_flag: std.atomic.Value(bool),
+};
+
+fn execVerifyMulti(pool: *ThreadPool, job: *VerifyMultiJob, worker_index: usize) void {
+    var pairing = Pairing.init(
+        &pool.pairing_bufs[worker_index].data,
+        true,
+        job.dst,
+    );
+
+    var did_work = false;
+    const n_elems = job.pks.len;
+
+    while (true) {
+        const i = job.counter.fetchAdd(1, .monotonic);
+        if (i >= n_elems) break;
+        if (job.err_flag.load(.acquire)) break;
+
+        did_work = true;
+
+        pairing.mulAndAggregate(
+            job.pks[i],
+            job.pks_validate,
+            job.sigs[i],
+            job.sigs_groupcheck,
+            &job.rands[i],
+            RAND_BITS,
+            &job.msgs[i],
+        ) catch {
+            job.err_flag.store(true, .release);
+            break;
+        };
+    }
+
+    if (did_work) pairing.commit();
+    pool.has_work[worker_index] = did_work;
+}
+
+/// Verifies multiple aggregate signatures in parallel using the thread pool.
+///
+/// This is the multi-threaded version of the same function in `fast_verify.zig`.
+pub fn verifyMultipleAggregateSignatures(
+    pool: *ThreadPool,
+    n_elems: usize,
+    msgs: []const [32]u8,
+    dst: []const u8,
+    pks: []const *PublicKey,
+    pks_validate: bool,
+    sigs: []const *Signature,
+    sigs_groupcheck: bool,
+    rands: []const [32]u8,
+) BlstError!bool {
+    if (n_elems == 0) return BlstError.VerifyFail;
+
+    // Single-threaded fallback for small inputs or single worker
+    if (n_elems <= 2 or pool.n_workers <= 1) {
+        const fast_verify = @import("fast_verify.zig");
+        return fast_verify.verifyMultipleAggregateSignatures(
+            &pool.pairing_bufs[0].data,
+            n_elems,
+            msgs,
+            dst,
+            pks,
+            pks_validate,
+            sigs,
+            sigs_groupcheck,
+            rands,
+        );
+    }
+
+    var job = VerifyMultiJob{
+        .pks = pks[0..n_elems],
+        .sigs = sigs[0..n_elems],
+        .msgs = msgs[0..n_elems],
+        .rands = rands[0..n_elems],
+        .dst = dst,
+        .pks_validate = pks_validate,
+        .sigs_groupcheck = sigs_groupcheck,
+        .counter = std.atomic.Value(usize).init(0),
+        .err_flag = std.atomic.Value(bool).init(false),
+    };
+
+    for (0..pool.n_workers) |i| {
+        pool.work_items[i] = &job;
+        pool.has_work[i] = false;
+    }
+
+    pool.dispatch();
+
+    if (job.err_flag.load(.acquire)) return BlstError.VerifyFail;
+
+    var acc_idx: ?usize = null;
+    for (0..pool.n_workers) |i| {
+        if (pool.has_work[i]) {
+            acc_idx = i;
+            break;
+        }
+    }
+
+    const first = acc_idx orelse return BlstError.VerifyFail;
+    var acc = Pairing{ .ctx = @ptrCast(&pool.pairing_bufs[first].data) };
+
+    for (first + 1..pool.n_workers) |i| {
+        if (pool.has_work[i]) {
+            const other = Pairing{ .ctx = @ptrCast(&pool.pairing_bufs[i].data) };
+            acc.merge(&other) catch return false;
+        }
+    }
+
+    return acc.finalVerify(null);
+}
+
+test "verifyMultipleAggregateSignatures multi-threaded" {
+    const pool = ThreadPool.get();
+    defer pool.deinit();
+
+    const ikm: [32]u8 = .{
+        0x93, 0xad, 0x7e, 0x65, 0xde, 0xad, 0x05, 0x2a, 0x08, 0x3a,
+        0x91, 0x0c, 0x8b, 0x72, 0x85, 0x91, 0x46, 0x4c, 0xca, 0x56,
+        0x60, 0x5b, 0xb0, 0x56, 0xed, 0xfe, 0x2b, 0x60, 0xa6, 0x3c,
+        0x48, 0x99,
+    };
+
+    const num_sigs = 16;
+
+    var msgs: [num_sigs][32]u8 = undefined;
+    var pks: [num_sigs]PublicKey = undefined;
+    var sigs: [num_sigs]Signature = undefined;
+    var pk_ptrs: [num_sigs]*PublicKey = undefined;
+    var sig_ptrs: [num_sigs]*Signature = undefined;
+
+    var prng = std.Random.DefaultPrng.init(blk: {
+        var seed: u64 = undefined;
+        std.posix.getrandom(std.mem.asBytes(&seed)) catch unreachable;
+        break :blk seed;
+    });
+    const rand = prng.random();
+
+    for (0..num_sigs) |i| {
+        std.Random.bytes(rand, &msgs[i]);
+        var ikm_i = ikm;
+        ikm_i[0] = @intCast(i & 0xff);
+        const sk = try SecretKey.keyGen(&ikm_i, null);
+        pks[i] = sk.toPublicKey();
+        sigs[i] = sk.sign(&msgs[i], blst.DST, null);
+        pk_ptrs[i] = &pks[i];
+        sig_ptrs[i] = &sigs[i];
+    }
+
+    var rands: [num_sigs][32]u8 = undefined;
+    for (&rands) |*r| std.Random.bytes(rand, r);
+
+    const result = try pool.verifyMultipleAggregateSignatures(
+        num_sigs,
+        &msgs,
+        blst.DST,
+        &pk_ptrs,
+        true,
+        &sig_ptrs,
+        true,
+        &rands,
+    );
+
+    try std.testing.expect(result);
+}

--- a/src/ThreadPool.zig
+++ b/src/ThreadPool.zig
@@ -42,6 +42,7 @@ partial_p2: [MAX_WORKERS]c.blst_p2 = undefined,
 has_work: [MAX_WORKERS]bool = [_]bool{false} ** MAX_WORKERS,
 
 var instance: ?*ThreadPool = null;
+var mutex: std.Thread.Mutex = .{};
 
 /// Pairing size is = ~3.1KB * `MAX_WORKERS` = ~50KB
 /// We allocate 4 pages (4 * 16KB) for this at startup.
@@ -49,6 +50,9 @@ const allocator = std.heap.page_allocator;
 
 /// Returns the global thread pool singleton, creating it if necessary.
 pub fn get() *ThreadPool {
+    mutex.lock();
+    defer mutex.unlock();
+
     if (instance) |pool| return pool;
     const pool = allocator.create(ThreadPool) catch
         @panic("ThreadPool: failed to allocate");
@@ -82,7 +86,9 @@ pub fn deinit(pool: *ThreadPool) void {
     for (pool.threads[0 .. n_workers - 1]) |t| {
         t.join();
     }
+    mutex.lock();
     if (instance == pool) instance = null;
+    mutex.unlock();
     allocator.destroy(pool);
 }
 

--- a/src/ThreadPool.zig
+++ b/src/ThreadPool.zig
@@ -61,6 +61,8 @@ pub fn get() *ThreadPool {
             break :blk @min(@max(cpu_count * 3 / 4, 2), MAX_WORKERS);
         },
     };
+    // Workers start from index 1 but executes as worker 0 inside dispatch() to avoid wasting a core.
+    // 0 is reserved for main thread.
     for (1..pool.n_workers) |i| {
         pool.threads[i - 1] = std.Thread.spawn(.{}, workerLoop, .{ pool, i }) catch
             @panic("ThreadPool: failed to spawn worker");
@@ -194,7 +196,12 @@ pub fn verifyMultipleAggregateSignatures(
     sigs_groupcheck: bool,
     rands: []const [32]u8,
 ) BlstError!bool {
-    if (n_elems == 0) return BlstError.VerifyFail;
+    if (n_elems == 0 or
+        pks.len != n_elems or
+        sigs.len != n_elems or
+        msgs.len != n_elems or
+        rands.len != n_elems)
+        return BlstError.VerifyFail;
 
     // Single-threaded fallback for small inputs or single worker
     if (n_elems <= 2 or pool.n_workers <= 1) {
@@ -276,7 +283,7 @@ fn execAggVerify(pool: *ThreadPool, job: *AggVerifyJob, worker_index: usize) voi
     }
 
     if (did_work) pairing.commit();
-    pool.has_work[worker_index] = true;
+    pool.has_work[worker_index] = did_work;
 }
 
 /// Verifies an aggregated signature against multiple messages and public keys
@@ -310,6 +317,8 @@ pub fn aggregateVerify(
 
     const n_active = @min(pool.n_workers, n_elems);
 
+    // Validate `sig` on the main thread (runs concurrently with merge below)
+    if (sig_groupcheck) sig.validate(false) catch return false;
     var job = AggVerifyJob{
         .pks = pks[0..n_elems],
         .msgs = msgs[0..n_elems],
@@ -325,8 +334,6 @@ pub fn aggregateVerify(
 
     if (job.err_flag.load(.acquire)) return false;
 
-    // Compute sig→GT on the main thread (runs concurrently with merge below)
-    if (sig_groupcheck) sig.validate(false) catch return false;
     var gtsig = c.blst_fp12{};
     Pairing.aggregated(&gtsig, sig);
 
@@ -335,7 +342,7 @@ pub fn aggregateVerify(
 
 /// Merges all of `pool`'s `pairing_bufs` and execute `finalVerify` on the accumulated `acc`.
 ///
-/// Stores the result in `gtsig`, returning `false` if verification fails.
+/// Perform final verification of `gtsig`, returning `false` if verification fails.
 fn mergeAndVerify(pool: *ThreadPool, n_active: usize, gtsig: ?*const c.blst_fp12) bool {
     var acc_idx: ?usize = null;
     for (0..n_active) |i| {

--- a/src/ThreadPool.zig
+++ b/src/ThreadPool.zig
@@ -343,7 +343,7 @@ pub fn aggregateVerify(
 /// Merges all of `pool`'s `pairing_bufs` and execute `finalVerify` on the accumulated `acc`.
 ///
 /// Perform final verification of `gtsig`, returning `false` if verification fails.
-fn mergeAndVerify(pool: *ThreadPool, n_active: usize, gtsig: ?*const c.blst_fp12) bool {
+fn mergeAndVerify(pool: *ThreadPool, n_active: usize, gtsig: ?*const c.blst_fp12) BlstError!bool {
     var acc_idx: ?usize = null;
     for (0..n_active) |i| {
         if (pool.has_work[i]) {
@@ -352,13 +352,13 @@ fn mergeAndVerify(pool: *ThreadPool, n_active: usize, gtsig: ?*const c.blst_fp12
         }
     }
 
-    const first = acc_idx orelse return false;
+    const first = acc_idx orelse return BlstError.MergeError;
     var acc = Pairing{ .ctx = @ptrCast(&pool.pairing_bufs[first].data) };
 
     for (first + 1..n_active) |i| {
         if (pool.has_work[i]) {
             const other = Pairing{ .ctx = @ptrCast(&pool.pairing_bufs[i].data) };
-            acc.merge(&other) catch return false;
+            try acc.merge(&other);
         }
     }
 

--- a/src/ThreadPool.zig
+++ b/src/ThreadPool.zig
@@ -15,23 +15,26 @@ const Signature = blst.Signature;
 const BlstError = @import("error.zig").BlstError;
 const SecretKey = @import("SecretKey.zig");
 
+/// This is pretty arbitrary
 pub const MAX_WORKERS: usize = 16;
 
 /// Number of random bits used for verification.
 const RAND_BITS = 64;
 
-/// Minimum number of elements before using multi-threaded aggregation.
-const AGGREGATION_MT_THRESHOLD = 64;
-
 const PairingBuf = struct {
     data: [Pairing.sizeOf()]u8 align(Pairing.buf_align) = undefined,
+};
+
+const WorkItem = union(enum) {
+    verify_multi: *VerifyMultiJob,
+    aggregate_verify: *AggVerifyJob,
 };
 
 n_workers: usize,
 threads: [MAX_WORKERS - 1]std.Thread = undefined,
 work_ready: [MAX_WORKERS]std.Thread.ResetEvent = [_]std.Thread.ResetEvent{.{}} ** MAX_WORKERS,
 work_done: [MAX_WORKERS]std.Thread.ResetEvent = [_]std.Thread.ResetEvent{.{}} ** MAX_WORKERS,
-work_items: [MAX_WORKERS]?*VerifyMultiJob = [_]?*VerifyMultiJob{null} ** MAX_WORKERS,
+work_items: [MAX_WORKERS]?WorkItem = [_]?WorkItem{null} ** MAX_WORKERS,
 shutdown: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 pairing_bufs: [MAX_WORKERS]PairingBuf = [_]PairingBuf{.{}} ** MAX_WORKERS,
 partial_p1: [MAX_WORKERS]c.blst_p1 = undefined,
@@ -81,6 +84,9 @@ pub fn deinit(pool: *ThreadPool) void {
     allocator.destroy(pool);
 }
 
+/// Handles a `WorkItem`.
+///
+/// Currently supports `aggregateVerify` and `verifyMultipleAggregateSignatures`.
 fn workerLoop(pool: *ThreadPool, worker_index: usize) void {
     while (true) {
         pool.work_ready[worker_index].wait();
@@ -88,32 +94,40 @@ fn workerLoop(pool: *ThreadPool, worker_index: usize) void {
 
         if (pool.shutdown.load(.acquire)) return;
 
-        const job = pool.work_items[worker_index] orelse {
+        const item = pool.work_items[worker_index] orelse {
             pool.work_done[worker_index].set();
             continue;
         };
 
-        execVerifyMulti(pool, job, worker_index);
+        switch (item) {
+            .verify_multi => |job| execVerifyMulti(pool, job, worker_index),
+            .aggregate_verify => |job| execAggVerify(pool, job, worker_index),
+        }
 
         pool.work_items[worker_index] = null;
         pool.work_done[worker_index].set();
     }
 }
 
-fn dispatch(pool: *ThreadPool) void {
+fn dispatch(pool: *ThreadPool, item: WorkItem, n_active: usize) void {
+    std.debug.assert(n_active <= pool.n_workers);
+
     // Signal background workers before main thread starts
-    for (1..pool.n_workers) |i| {
+    for (1..n_active) |i| {
+        pool.work_items[i] = item;
         pool.work_ready[i].set();
     }
 
     // Main thread executes as worker 0
-    if (pool.work_items[0]) |job| {
-        execVerifyMulti(pool, job, 0);
-        pool.work_items[0] = null;
+    pool.work_items[0] = item;
+    switch (item) {
+        .verify_multi => |job| execVerifyMulti(pool, job, 0),
+        .aggregate_verify => |job| execAggVerify(pool, job, 0),
     }
+    pool.work_items[0] = null;
 
     // Wait for all background workers
-    for (1..pool.n_workers) |i| {
+    for (1..n_active) |i| {
         pool.work_done[i].wait();
         pool.work_done[i].reset();
     }
@@ -198,6 +212,8 @@ pub fn verifyMultipleAggregateSignatures(
         );
     }
 
+    const n_active = @min(pool.n_workers, n_elems);
+
     var job = VerifyMultiJob{
         .pks = pks[0..n_elems],
         .sigs = sigs[0..n_elems],
@@ -210,34 +226,136 @@ pub fn verifyMultipleAggregateSignatures(
         .err_flag = std.atomic.Value(bool).init(false),
     };
 
-    for (0..pool.n_workers) |i| {
-        pool.work_items[i] = &job;
-        pool.has_work[i] = false;
-    }
-
-    pool.dispatch();
+    @memset(pool.has_work[0..n_active], false);
+    pool.dispatch(.{ .verify_multi = &job }, n_active);
 
     if (job.err_flag.load(.acquire)) return BlstError.VerifyFail;
 
+    return mergeAndVerify(pool, n_active, null);
+}
+
+const AggVerifyJob = struct {
+    pks: []const *PublicKey,
+    msgs: []const [32]u8,
+    dst: []const u8,
+    pks_validate: bool,
+    n_elems: usize,
+    counter: std.atomic.Value(usize),
+    err_flag: std.atomic.Value(bool),
+};
+
+fn execAggVerify(pool: *ThreadPool, job: *AggVerifyJob, worker_index: usize) void {
+    var pairing = Pairing.init(
+        &pool.pairing_bufs[worker_index].data,
+        true,
+        job.dst,
+    );
+
+    var did_work = false;
+
+    while (true) {
+        const i = job.counter.fetchAdd(1, .monotonic);
+        if (i >= job.n_elems) break;
+        if (job.err_flag.load(.acquire)) break;
+
+        did_work = true;
+
+        // Workers only aggregate pk+msg pairs; the signature is handled
+        // separately on the main thread after dispatch.
+        pairing.aggregate(
+            job.pks[i],
+            job.pks_validate,
+            null,
+            false,
+            &job.msgs[i],
+            null,
+        ) catch {
+            job.err_flag.store(true, .release);
+            break;
+        };
+    }
+
+    if (did_work) pairing.commit();
+    pool.has_work[worker_index] = true;
+}
+
+/// Verifies an aggregated signature against multiple messages and public keys
+/// in parallel using the thread pool.
+///
+/// This is the multi-threaded version of `Signature.aggregateVerify`.
+pub fn aggregateVerify(
+    pool: *ThreadPool,
+    sig: *const Signature,
+    sig_groupcheck: bool,
+    msgs: []const [32]u8,
+    dst: []const u8,
+    pks: []const *PublicKey,
+    pks_validate: bool,
+) bool {
+    const n_elems = pks.len;
+    if (n_elems == 0 or msgs.len != n_elems) return false;
+
+    // Single-threaded fallback
+    if (n_elems <= 2 or pool.n_workers <= 1) {
+        var pairing = Pairing.init(&pool.pairing_bufs[0].data, true, dst);
+        pairing.aggregate(pks[0], pks_validate, sig, sig_groupcheck, &msgs[0], null) catch return false;
+        for (1..n_elems) |i| {
+            pairing.aggregate(pks[i], pks_validate, null, false, &msgs[i], null) catch return false;
+        }
+        pairing.commit();
+        var gtsig = c.blst_fp12{};
+        Pairing.aggregated(&gtsig, sig);
+        return pairing.finalVerify(&gtsig);
+    }
+
+    const n_active = @min(pool.n_workers, n_elems);
+
+    var job = AggVerifyJob{
+        .pks = pks[0..n_elems],
+        .msgs = msgs[0..n_elems],
+        .dst = dst,
+        .pks_validate = pks_validate,
+        .n_elems = n_elems,
+        .counter = std.atomic.Value(usize).init(0),
+        .err_flag = std.atomic.Value(bool).init(false),
+    };
+
+    @memset(pool.has_work[0..n_active], false);
+    pool.dispatch(.{ .aggregate_verify = &job }, n_active);
+
+    if (job.err_flag.load(.acquire)) return false;
+
+    // Compute sig→GT on the main thread (runs concurrently with merge below)
+    if (sig_groupcheck) sig.validate(false) catch return false;
+    var gtsig = c.blst_fp12{};
+    Pairing.aggregated(&gtsig, sig);
+
+    return mergeAndVerify(pool, n_active, &gtsig);
+}
+
+/// Merges all of `pool`'s `pairing_bufs` and execute `finalVerify` on the accumulated `acc`.
+///
+/// Stores the result in `gtsig`, returning `false` if verification fails.
+fn mergeAndVerify(pool: *ThreadPool, n_active: usize, gtsig: ?*const c.blst_fp12) bool {
     var acc_idx: ?usize = null;
-    for (0..pool.n_workers) |i| {
+    for (0..n_active) |i| {
         if (pool.has_work[i]) {
             acc_idx = i;
             break;
         }
     }
 
-    const first = acc_idx orelse return BlstError.VerifyFail;
+    const first = acc_idx orelse return false;
     var acc = Pairing{ .ctx = @ptrCast(&pool.pairing_bufs[first].data) };
 
-    for (first + 1..pool.n_workers) |i| {
+    for (first + 1..n_active) |i| {
         if (pool.has_work[i]) {
             const other = Pairing{ .ctx = @ptrCast(&pool.pairing_bufs[i].data) };
             acc.merge(&other) catch return false;
         }
     }
 
-    return acc.finalVerify(null);
+    return acc.finalVerify(gtsig);
 }
 
 test "verifyMultipleAggregateSignatures multi-threaded" {
@@ -289,6 +407,58 @@ test "verifyMultipleAggregateSignatures multi-threaded" {
         &sig_ptrs,
         true,
         &rands,
+    );
+
+    try std.testing.expect(result);
+}
+
+test "aggregateVerify multi-threaded" {
+    const pool = ThreadPool.get();
+    defer pool.deinit();
+
+    const AggregateSignature = blst.AggregateSignature;
+
+    const ikm: [32]u8 = .{
+        0x93, 0xad, 0x7e, 0x65, 0xde, 0xad, 0x05, 0x2a, 0x08, 0x3a,
+        0x91, 0x0c, 0x8b, 0x72, 0x85, 0x91, 0x46, 0x4c, 0xca, 0x56,
+        0x60, 0x5b, 0xb0, 0x56, 0xed, 0xfe, 0x2b, 0x60, 0xa6, 0x3c,
+        0x48, 0x99,
+    };
+
+    const num_sigs = 16;
+
+    var msgs: [num_sigs][32]u8 = undefined;
+    var pks: [num_sigs]PublicKey = undefined;
+    var sigs: [num_sigs]Signature = undefined;
+    var pk_ptrs: [num_sigs]*PublicKey = undefined;
+
+    var prng = std.Random.DefaultPrng.init(blk: {
+        var seed: u64 = undefined;
+        std.posix.getrandom(std.mem.asBytes(&seed)) catch unreachable;
+        break :blk seed;
+    });
+    const rand = prng.random();
+
+    for (0..num_sigs) |i| {
+        std.Random.bytes(rand, &msgs[i]);
+        var ikm_i = ikm;
+        ikm_i[0] = @intCast(i & 0xff);
+        const sk = try SecretKey.keyGen(&ikm_i, null);
+        pks[i] = sk.toPublicKey();
+        sigs[i] = sk.sign(&msgs[i], blst.DST, null);
+        pk_ptrs[i] = &pks[i];
+    }
+
+    const agg_sig = AggregateSignature.aggregate(&sigs, false) catch return error.AggregationFailed;
+    const final_sig = agg_sig.toSignature();
+
+    const result = pool.aggregateVerify(
+        &final_sig,
+        false,
+        &msgs,
+        blst.DST,
+        &pk_ptrs,
+        true,
     );
 
     try std.testing.expect(result);

--- a/src/ThreadPool.zig
+++ b/src/ThreadPool.zig
@@ -30,6 +30,11 @@ const WorkItem = union(enum) {
     aggregate_verify: *AggVerifyJob,
 };
 
+pub const Opts = struct {
+    n_workers: u16 = 1,
+};
+
+allocator: std.mem.Allocator,
 n_workers: usize,
 threads: [MAX_WORKERS - 1]std.Thread = undefined,
 work_ready: [MAX_WORKERS]std.Thread.ResetEvent = [_]std.Thread.ResetEvent{.{}} ** MAX_WORKERS,
@@ -43,38 +48,19 @@ has_work: [MAX_WORKERS]bool = [_]bool{false} ** MAX_WORKERS,
 /// Mutex for dispatching multi-threaded verification work.
 dispatch_mutex: std.Thread.Mutex = .{},
 
-var instance: ?*ThreadPool = null;
-/// Mutex responsible for access to the global `ThreadPool` singleton.
-var pool_mutex: std.Thread.Mutex = .{};
-
-/// Pairing size is = ~3.1KB * `MAX_WORKERS` = ~50KB
-/// We allocate 4 pages (4 * 16KB) for this at startup.
-const allocator = std.heap.page_allocator;
-
-/// Returns the global thread pool singleton, creating it if necessary.
-pub fn get() *ThreadPool {
-    pool_mutex.lock();
-    defer pool_mutex.unlock();
-
-    if (instance) |pool| return pool;
+/// Creates a thread pool with the specified number of workers.
+/// The caller owns the returned pool and must call `deinit` when done.
+pub fn init(allocator: std.mem.Allocator, opts: Opts) *ThreadPool {
+    std.debug.assert(opts.n_workers >= 1 and opts.n_workers <= MAX_WORKERS);
     const pool = allocator.create(ThreadPool) catch
         @panic("ThreadPool: failed to allocate");
-    pool.* = .{
-        .n_workers = blk: {
-            const cpu_count = std.Thread.getCpuCount() catch 1;
-            // Use 3/4 of available cores: aggregation saturates early so doesn't
-            // need all cores, while leaving headroom for the host application
-            // (e.g. Node.js event loop, libuv I/O threads).
-            break :blk @min(@max(cpu_count * 3 / 4, 2), MAX_WORKERS);
-        },
-    };
-    // Workers start from index 1 but executes as worker 0 inside dispatch() to avoid wasting a core.
-    // 0 is reserved for main thread.
+    pool.* = .{ .allocator = allocator, .n_workers = opts.n_workers };
+    // Workers start from index 1; index 0 is reserved for the calling thread
+    // which executes as worker 0 inside dispatch() to avoid wasting a core.
     for (1..pool.n_workers) |i| {
         pool.threads[i - 1] = std.Thread.spawn(.{}, workerLoop, .{ pool, i }) catch
             @panic("ThreadPool: failed to spawn worker");
     }
-    instance = pool;
     return pool;
 }
 
@@ -89,10 +75,7 @@ pub fn deinit(pool: *ThreadPool) void {
     for (pool.threads[0 .. n_workers - 1]) |t| {
         t.join();
     }
-    pool_mutex.lock();
-    if (instance == pool) instance = null;
-    pool_mutex.unlock();
-    allocator.destroy(pool);
+    pool.allocator.destroy(pool);
 }
 
 /// Handles a `WorkItem`.
@@ -381,7 +364,7 @@ fn mergeAndVerify(pool: *ThreadPool, n_active: usize, gtsig: ?*const c.blst_fp12
 }
 
 test "verifyMultipleAggregateSignatures multi-threaded" {
-    const pool = ThreadPool.get();
+    const pool = ThreadPool.init(std.testing.allocator, .{ .n_workers = 4 });
     defer pool.deinit();
 
     const ikm: [32]u8 = .{
@@ -435,7 +418,7 @@ test "verifyMultipleAggregateSignatures multi-threaded" {
 }
 
 test "aggregateVerify multi-threaded" {
-    const pool = ThreadPool.get();
+    const pool = ThreadPool.init(std.testing.allocator, .{ .n_workers = 4 });
     defer pool.deinit();
 
     const AggregateSignature = blst.AggregateSignature;

--- a/src/error.zig
+++ b/src/error.zig
@@ -10,6 +10,7 @@ pub const BlstError = error{
     VerifyFail,
     PkIsInfinity,
     BadScalar,
+    MergeError,
 };
 
 pub fn intFromError(e: BlstError) c_uint {
@@ -21,6 +22,7 @@ pub fn intFromError(e: BlstError) c_uint {
         BlstError.VerifyFail => c.BLST_VERIFY_FAIL,
         BlstError.PkIsInfinity => c.BLST_PK_IS_INFINITY,
         BlstError.BadScalar => c.BLST_BAD_SCALAR,
+        BlstError.MergeError => c.BLST_BAD_SCALAR + 1,
     };
 }
 

--- a/src/fast_verify.zig
+++ b/src/fast_verify.zig
@@ -14,9 +14,9 @@ pub fn verifyMultipleAggregateSignatures(
     n_elems: usize,
     msgs: []const [32]u8,
     dst: []const u8,
-    pks: []const *PublicKey,
+    pks: []const *const PublicKey,
     pks_validate: bool,
-    sigs: []const *Signature,
+    sigs: []const *const Signature,
     sigs_groupcheck: bool,
     rands: []const [32]u8,
 ) BlstError!bool {

--- a/src/root.zig
+++ b/src/root.zig
@@ -16,6 +16,7 @@ pub const AggregateSignature = @import("AggregateSignature.zig");
 pub const BlstError = @import("error.zig").BlstError;
 
 pub const verifyMultipleAggregateSignatures = @import("fast_verify.zig").verifyMultipleAggregateSignatures;
+pub const ThreadPool = @import("ThreadPool.zig");
 
 /// Maximum number of signatures that can be aggregated in a single job.
 pub const MAX_AGGREGATE_PER_JOB: usize = 128;
@@ -33,4 +34,5 @@ test {
     testing.refAllDecls(Signature);
     testing.refAllDecls(AggregatePublicKey);
     testing.refAllDecls(AggregateSignature);
+    testing.refAllDecls(ThreadPool);
 }

--- a/test/spec/test_case.zig
+++ b/test/spec/test_case.zig
@@ -80,6 +80,8 @@ pub fn aggregate_verify(gpa: Allocator, path: std.fs.Dir) !void {
 
         const pubkeys = try allocator.alloc(blst.PublicKey, num_sigs);
         defer allocator.free(pubkeys);
+        const pk_ptrs = try allocator.alloc(*const blst.PublicKey, num_sigs);
+        defer allocator.free(pk_ptrs);
         const messages = try allocator.alloc([32]u8, num_sigs);
         defer allocator.free(messages);
 
@@ -93,6 +95,7 @@ pub fn aggregate_verify(gpa: Allocator, path: std.fs.Dir) !void {
                 pk_hex_bytes[2..], // skip "0x" prefix
             );
             pubkeys[i] = try blst.PublicKey.deserialize(pk_bytes);
+            pk_ptrs[i] = &pubkeys[i];
         }
 
         for (aggregate_verify_test_data.input.messages, 0..) |msg_hex_bytes, i| {
@@ -117,7 +120,7 @@ pub fn aggregate_verify(gpa: Allocator, path: std.fs.Dir) !void {
             &pairing_buf,
             messages,
             blst.DST,
-            pubkeys,
+            pk_ptrs,
             true,
         ) catch false;
         try std.testing.expectEqual(aggregate_verify_test_data.output, result);


### PR DESCRIPTION
Update the signature of `aggregateVerify` to take a slice of `pk`s and `sig`s as pointers for reusability in the multi-threaded version.
This also includes updating the signatures in the job structs, see `AggVerifyJob`